### PR TITLE
Setup React Navigation

### DIFF
--- a/WeedGrowApp/app/_layout.tsx
+++ b/WeedGrowApp/app/_layout.tsx
@@ -1,8 +1,13 @@
-import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
+import {
+  DarkTheme,
+  DefaultTheme,
+  NavigationContainer,
+  ThemeProvider,
+} from '@react-navigation/native';
 import { useFonts } from 'expo-font';
-import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
+import RootNavigator from '@/navigation/RootNavigator';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
 
@@ -17,12 +22,13 @@ export default function RootLayout() {
     return null;
   }
 
+  const theme = colorScheme === 'dark' ? DarkTheme : DefaultTheme;
+
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="+not-found" />
-      </Stack>
+    <ThemeProvider value={theme}>
+      <NavigationContainer theme={theme}>
+        <RootNavigator />
+      </NavigationContainer>
       <StatusBar style="auto" />
     </ThemeProvider>
   );

--- a/WeedGrowApp/navigation/RootNavigator.tsx
+++ b/WeedGrowApp/navigation/RootNavigator.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+import HomeScreen from '@/screens/HomeScreen';
+import AddPlantScreen from '@/screens/AddPlantScreen';
+import PlantDetailScreen from '@/screens/PlantDetailScreen';
+
+export type RootStackParamList = {
+  Home: undefined;
+  AddPlant: undefined;
+  PlantDetail: undefined;
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export default function RootNavigator() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen name="Home" component={HomeScreen} />
+      <Stack.Screen name="AddPlant" component={AddPlantScreen} />
+      <Stack.Screen name="PlantDetail" component={PlantDetailScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/WeedGrowApp/package-lock.json
+++ b/WeedGrowApp/package-lock.json
@@ -33,7 +33,8 @@
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
         "react-native-web": "~0.20.0",
-        "react-native-webview": "13.13.5"
+        "react-native-webview": "13.13.5",
+        "@react-navigation/native-stack": "^7.3.10"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",

--- a/WeedGrowApp/package.json
+++ b/WeedGrowApp/package.json
@@ -15,6 +15,7 @@
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
+    "@react-navigation/native-stack": "^7.3.10",
     "expo": "~53.0.9",
     "expo-blur": "~14.1.4",
     "expo-constants": "~17.1.6",

--- a/WeedGrowApp/screens/AddPlantScreen.tsx
+++ b/WeedGrowApp/screens/AddPlantScreen.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function AddPlantScreen() {
+  return (
+    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <ThemedText type="title">Add Plant</ThemedText>
+    </ThemedView>
+  );
+}

--- a/WeedGrowApp/screens/HomeScreen.tsx
+++ b/WeedGrowApp/screens/HomeScreen.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function HomeScreen() {
+  return (
+    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <ThemedText type="title">Home</ThemedText>
+    </ThemedView>
+  );
+}

--- a/WeedGrowApp/screens/PlantDetailScreen.tsx
+++ b/WeedGrowApp/screens/PlantDetailScreen.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function PlantDetailScreen() {
+  return (
+    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <ThemedText type="title">Plant Detail</ThemedText>
+    </ThemedView>
+  );
+}


### PR DESCRIPTION
## Summary
- install `@react-navigation/native-stack`
- create placeholder screens for Home, AddPlant and PlantDetail
- add `RootNavigator` with a stack navigator
- wrap the app with `NavigationContainer`

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684185a84b308330ae5bdda23ad3cebf