### PR TITLE
Add basic navigation screens

### DIFF
--- a/WeedGrowApp/screens/AddPlantScreen.tsx
+++ b/WeedGrowApp/screens/AddPlantScreen.tsx
@@ -1,11 +1,28 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Button, TextInput } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
+import type { RootStackParamList } from '@/navigation/RootNavigator';
 
 export default function AddPlantScreen() {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const [name, setName] = useState('');
+
   return (
-    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <ThemedText type="title">Add Plant</ThemedText>
+    <ThemedView style={{ flex: 1, padding: 16 }}>
+      <Button title="Back" onPress={() => navigation.goBack()} />
+      <ThemedText type="title" style={{ marginTop: 16 }}>
+        Add Plant
+      </ThemedText>
+      <TextInput
+        placeholder="Plant name"
+        value={name}
+        onChangeText={setName}
+        style={{ borderWidth: 1, marginTop: 16, padding: 8 }}
+      />
     </ThemedView>
   );
 }

--- a/WeedGrowApp/screens/HomeScreen.tsx
+++ b/WeedGrowApp/screens/HomeScreen.tsx
@@ -1,11 +1,19 @@
 import React from 'react';
+import { Button } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
+import type { RootStackParamList } from '@/navigation/RootNavigator';
 
 export default function HomeScreen() {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+
   return (
     <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       <ThemedText type="title">Home</ThemedText>
+      <Button title="Add Plant" onPress={() => navigation.navigate('AddPlant')} />
     </ThemedView>
   );
 }

--- a/WeedGrowApp/screens/PlantDetailScreen.tsx
+++ b/WeedGrowApp/screens/PlantDetailScreen.tsx
@@ -6,6 +6,7 @@ export default function PlantDetailScreen() {
   return (
     <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       <ThemedText type="title">Plant Detail</ThemedText>
+      <ThemedText>Details coming soon...</ThemedText>
     </ThemedView>
   );
 }


### PR DESCRIPTION
## Summary
- add navigation button on Home screen
- add back button and text input on AddPlant screen
- tweak PlantDetail screen placeholder

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm run lint` in `weed-grow-web` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68419787ee108330929e74ab576cf59c