### PR TITLE
Add bottom tab navigation

### DIFF
--- a/WeedGrowApp/app/(tabs)/_layout.tsx
+++ b/WeedGrowApp/app/(tabs)/_layout.tsx
@@ -30,14 +30,36 @@ export default function TabLayout() {
         name="index"
         options={{
           title: 'Home',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="house.fill" color={color} />,
+          tabBarIcon: ({ color }) => (
+            <IconSymbol size={28} name="house.fill" color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="plants"
+        options={{
+          title: 'Plants',
+          tabBarIcon: ({ color }) => (
+            <IconSymbol size={28} name="leaf.fill" color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="gallery"
+        options={{
+          title: 'Gallery',
+          tabBarIcon: ({ color }) => (
+            <IconSymbol size={28} name="photo.on.rectangle" color={color} />
+          ),
         }}
       />
       <Tabs.Screen
         name="explore"
         options={{
           title: 'Explore',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
+          tabBarIcon: ({ color }) => (
+            <IconSymbol size={28} name="paperplane.fill" color={color} />
+          ),
         }}
       />
     </Tabs>

--- a/WeedGrowApp/app/(tabs)/gallery.tsx
+++ b/WeedGrowApp/app/(tabs)/gallery.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function GalleryScreen() {
+  return (
+    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <ThemedText type="title">Gallery</ThemedText>
+      <ThemedText>Coming soon...</ThemedText>
+    </ThemedView>
+  );
+}

--- a/WeedGrowApp/app/(tabs)/plants.tsx
+++ b/WeedGrowApp/app/(tabs)/plants.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Button } from 'react-native';
+import { useRouter } from 'expo-router';
+
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function PlantsScreen() {
+  const router = useRouter();
+  return (
+    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <ThemedText type="title">Plants</ThemedText>
+      <Button title="Add Plant" onPress={() => router.push('/add-plant')} />
+    </ThemedView>
+  );
+}

--- a/WeedGrowApp/app/index.tsx
+++ b/WeedGrowApp/app/index.tsx
@@ -1,16 +1,5 @@
-import React from 'react';
-import { Button } from 'react-native';
-import { useRouter } from 'expo-router';
+import { Redirect } from 'expo-router';
 
-import { ThemedView } from '@/components/ThemedView';
-import { ThemedText } from '@/components/ThemedText';
-export default function HomeScreen() {
-  const router = useRouter();
-
-  return (
-    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <ThemedText type="title">Home</ThemedText>
-      <Button title="Add Plant" onPress={() => router.push('/add-plant')} />
-    </ThemedView>
-  );
+export default function Index() {
+  return <Redirect href="/(tabs)" />;
 }

--- a/WeedGrowApp/components/ui/IconSymbol.tsx
+++ b/WeedGrowApp/components/ui/IconSymbol.tsx
@@ -15,6 +15,8 @@ type IconSymbolName = keyof typeof MAPPING;
  */
 const MAPPING = {
   'house.fill': 'home',
+  'leaf.fill': 'local-florist',
+  'photo.on.rectangle': 'photo-library',
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',


### PR DESCRIPTION
## Summary
- redirect the default route to the tabs layout
- map additional icons for plants and gallery
- add Plants and Gallery tab screens
- update tab layout to show four items

## Testing
- `npm run lint` (fails: `expo` not found)
- `npm run lint` in web app (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_6841ba6b5fb88330af008d2151c62871