### PR TITLE
Add five-tab layout with new screens

### DIFF
--- a/WeedGrowApp/app/(tabs)/_layout.tsx
+++ b/WeedGrowApp/app/(tabs)/_layout.tsx
@@ -27,11 +27,11 @@ export default function TabLayout() {
         }),
       }}>
       <Tabs.Screen
-        name="index"
+        name="unknown"
         options={{
-          title: 'Home',
+          title: 'Unknown',
           tabBarIcon: ({ color }) => (
-            <IconSymbol size={28} name="house.fill" color={color} />
+            <IconSymbol size={28} name="questionmark.circle" color={color} />
           ),
         }}
       />
@@ -45,20 +45,29 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
-        name="gallery"
+        name="index"
         options={{
-          title: 'Gallery',
+          title: 'Home',
           tabBarIcon: ({ color }) => (
-            <IconSymbol size={28} name="photo.on.rectangle" color={color} />
+            <IconSymbol size={28} name="house.fill" color={color} />
           ),
         }}
       />
       <Tabs.Screen
-        name="explore"
+        name="learn"
         options={{
-          title: 'Explore',
+          title: 'Learn',
           tabBarIcon: ({ color }) => (
-            <IconSymbol size={28} name="paperplane.fill" color={color} />
+            <IconSymbol size={28} name="book.fill" color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="more"
+        options={{
+          title: 'More',
+          tabBarIcon: ({ color }) => (
+            <IconSymbol size={28} name="ellipsis.circle" color={color} />
           ),
         }}
       />

--- a/WeedGrowApp/app/(tabs)/learn.tsx
+++ b/WeedGrowApp/app/(tabs)/learn.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function LearnScreen() {
+  return (
+    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <ThemedText type="title">Learn</ThemedText>
+      <ThemedText>Coming soon...</ThemedText>
+    </ThemedView>
+  );
+}

--- a/WeedGrowApp/app/(tabs)/more.tsx
+++ b/WeedGrowApp/app/(tabs)/more.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function MoreScreen() {
+  return (
+    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <ThemedText type="title">More</ThemedText>
+      <ThemedText>Settings and more coming soon...</ThemedText>
+    </ThemedView>
+  );
+}

--- a/WeedGrowApp/app/(tabs)/unknown.tsx
+++ b/WeedGrowApp/app/(tabs)/unknown.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function UnknownScreen() {
+  return (
+    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <ThemedText type="title">Unknown</ThemedText>
+      <ThemedText>Coming soon...</ThemedText>
+    </ThemedView>
+  );
+}

--- a/WeedGrowApp/components/ui/IconSymbol.tsx
+++ b/WeedGrowApp/components/ui/IconSymbol.tsx
@@ -20,6 +20,9 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'questionmark.circle': 'help-outline',
+  'book.fill': 'menu-book',
+  'ellipsis.circle': 'more-horiz',
 } as IconMapping;
 
 /**


### PR DESCRIPTION
## Summary
- add Unknown, Learn, and More placeholder screens
- remap icons for new screens
- change tabs layout to five icons including the new screens

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm run lint` in weed-grow-web *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6841d2d6e38c83308a9c9dd70f61ea75