### PR TITLE
Improve add-plant flow styling

### DIFF
--- a/WeedGrowApp/app/add-plant/review.tsx
+++ b/WeedGrowApp/app/add-plant/review.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { ScrollView, View } from 'react-native';
-import { Button, Card, Text } from 'react-native-paper';
+import { ScrollView, View, Image } from 'react-native';
+import { Button, Card, Text, Divider } from 'react-native-paper';
 import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
@@ -17,25 +17,141 @@ export default function Review() {
   };
 
   return (
-    <ScrollView contentContainerStyle={{ padding: 16 }}>
+    <ScrollView contentContainerStyle={{ padding: 24, gap: 16 }}>
       <StepIndicatorBar currentPosition={4} />
-      <Card style={{ marginTop: 16 }}>
+
+      <Card>
         <Card.Title title="Review Plant" />
         <Card.Content>
-          {Object.entries(form).map(([key, value]) => {
-            if (typeof value === 'function') return null;
-            return (
-              <View key={key} style={{ marginBottom: 8 }}>
-                <Text variant="labelLarge">{key}</Text>
-                <Text>{JSON.stringify(value)}</Text>
-              </View>
-            );
-          })}
+          <View style={{ gap: 8 }}>
+            <View>
+              <Text variant="labelLarge">Name</Text>
+              <Text>{form.name}</Text>
+            </View>
+            <Divider />
+            <View>
+              <Text variant="labelLarge">Strain</Text>
+              <Text>{form.strain}</Text>
+            </View>
+            <Divider />
+            <View>
+              <Text variant="labelLarge">Growth Stage</Text>
+              <Text>{form.growthStage}</Text>
+            </View>
+            <Divider />
+            <View>
+              <Text variant="labelLarge">Environment</Text>
+              <Text>{form.environment}</Text>
+            </View>
+            {form.plantedIn && (
+              <>
+                <Divider />
+                <View>
+                  <Text variant="labelLarge">Planted In</Text>
+                  <Text>{form.plantedIn}</Text>
+                </View>
+              </>
+            )}
+            {form.potSize && (
+              <>
+                <Divider />
+                <View>
+                  <Text variant="labelLarge">Pot Size</Text>
+                  <Text>{form.potSize}</Text>
+                </View>
+              </>
+            )}
+            {form.sunlightExposure && (
+              <>
+                <Divider />
+                <View>
+                  <Text variant="labelLarge">Sunlight</Text>
+                  <Text>{form.sunlightExposure}</Text>
+                </View>
+              </>
+            )}
+            {form.location && (
+              <>
+                <Divider />
+                <View>
+                  <Text variant="labelLarge">Location</Text>
+                  <Text>
+                    {form.location.lat}, {form.location.lng}
+                  </Text>
+                </View>
+              </>
+            )}
+            {form.locationNickname && (
+              <>
+                <Divider />
+                <View>
+                  <Text variant="labelLarge">Location Nickname</Text>
+                  <Text>{form.locationNickname}</Text>
+                </View>
+              </>
+            )}
+            {form.wateringFrequency && (
+              <>
+                <Divider />
+                <View>
+                  <Text variant="labelLarge">Watering</Text>
+                  <Text>{form.wateringFrequency}</Text>
+                </View>
+              </>
+            )}
+            {form.fertilizer && (
+              <>
+                <Divider />
+                <View>
+                  <Text variant="labelLarge">Fertilizer</Text>
+                  <Text>{form.fertilizer}</Text>
+                </View>
+              </>
+            )}
+            {form.pests && form.pests.length > 0 && (
+              <>
+                <Divider />
+                <View>
+                  <Text variant="labelLarge">Pests</Text>
+                  <Text>{form.pests.join(', ')}</Text>
+                </View>
+              </>
+            )}
+            {form.trainingTags && form.trainingTags.length > 0 && (
+              <>
+                <Divider />
+                <View>
+                  <Text variant="labelLarge">Training</Text>
+                  <Text>{form.trainingTags.join(', ')}</Text>
+                </View>
+              </>
+            )}
+            {form.notes && (
+              <>
+                <Divider />
+                <View>
+                  <Text variant="labelLarge">Notes</Text>
+                  <Text>{form.notes}</Text>
+                </View>
+              </>
+            )}
+            {form.imageUri && (
+              <>
+                <Divider />
+                <Image source={{ uri: form.imageUri }} style={{ height: 200, borderRadius: 8 }} />
+              </>
+            )}
+          </View>
         </Card.Content>
       </Card>
+
       <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 24 }}>
-        <Button mode="outlined" onPress={() => router.back()}>Back</Button>
-        <Button mode="contained" onPress={save}>Save Plant</Button>
+        <Button mode="outlined" onPress={() => router.back()}>
+          Back
+        </Button>
+        <Button mode="contained" onPress={save}>
+          Save Plant
+        </Button>
       </View>
     </ScrollView>
   );

--- a/WeedGrowApp/app/add-plant/step1.tsx
+++ b/WeedGrowApp/app/add-plant/step1.tsx
@@ -1,6 +1,19 @@
 import React from 'react';
-import { ScrollView, KeyboardAvoidingView, Platform, View } from 'react-native';
-import { TextInput, Button, RadioButton } from 'react-native-paper';
+import {
+  ScrollView,
+  KeyboardAvoidingView,
+  Platform,
+  View,
+  TouchableWithoutFeedback,
+  Keyboard,
+} from 'react-native';
+import {
+  TextInput,
+  Button,
+  SegmentedButtons,
+  Text,
+  Menu,
+} from 'react-native-paper';
 import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
@@ -11,48 +24,88 @@ export default function Step1() {
   const { name, strain, growthStage, setField } = usePlantForm();
 
   const isValid = name.trim().length > 0;
+  const [strainMenu, setStrainMenu] = React.useState(false);
+
+  const inputStyle = {
+    backgroundColor: '#f5f5f5',
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    color: '#333',
+  } as const;
 
   return (
     <KeyboardAvoidingView
       style={{ flex: 1 }}
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
     >
-      <ScrollView contentContainerStyle={{ padding: 16 }}>
-        <StepIndicatorBar currentPosition={0} />
-        <TextInput
-          label="Plant Name"
-          value={name}
-          onChangeText={(text) => setField('name', text)}
-          style={{ marginTop: 16 }}
-        />
-        <TextInput
-          label="Strain"
-          value={strain}
-          onChangeText={(text) => setField('strain', text)}
-          style={{ marginTop: 16 }}
-        />
-        <RadioButton.Group
-          onValueChange={(val) => setField('growthStage', val as any)}
-          value={growthStage}
-        >
-          <RadioButton.Item label="Germination" value="germination" />
-          <RadioButton.Item label="Seedling" value="seedling" />
-          <RadioButton.Item label="Vegetative" value="vegetative" />
-          <RadioButton.Item label="Flowering" value="flowering" />
-        </RadioButton.Group>
-        <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 24 }}>
-          <Button mode="outlined" onPress={() => router.back()}>
-            Back
-          </Button>
-          <Button
-            mode="contained"
-            disabled={!isValid}
-            onPress={() => router.push('/add-plant/step2')}
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+        <ScrollView contentContainerStyle={{ padding: 24, gap: 16 }}>
+          <StepIndicatorBar currentPosition={0} />
+          <Text variant="titleLarge">🌱 Let’s start with the basics</Text>
+
+          <TextInput
+            label="Plant Name"
+            value={name}
+            onChangeText={(text) => setField('name', text)}
+            style={inputStyle}
+          />
+
+          <Menu
+            visible={strainMenu}
+            onDismiss={() => setStrainMenu(false)}
+            anchor={
+              <TextInput
+                label="Strain"
+                value={strain}
+                onChangeText={(text) => setField('strain', text)}
+                style={inputStyle}
+                right={
+                  <TextInput.Icon
+                    icon="menu-down"
+                    onPress={() => setStrainMenu(true)}
+                  />
+                }
+              />
+            }
           >
-            Next
-          </Button>
-        </View>
-      </ScrollView>
+            {['Unknown', 'Sativa', 'Indica', 'Hybrid'].map((opt) => (
+              <Menu.Item
+                key={opt}
+                onPress={() => {
+                  setField('strain', opt);
+                  setStrainMenu(false);
+                }}
+                title={opt}
+              />
+            ))}
+          </Menu>
+
+          <SegmentedButtons
+            value={growthStage}
+            onValueChange={(val) => setField('growthStage', val as any)}
+            buttons={[
+              { value: 'germination', label: 'Germination' },
+              { value: 'seedling', label: 'Seedling' },
+              { value: 'vegetative', label: 'Vegetative' },
+              { value: 'flowering', label: 'Flowering' },
+            ]}
+          />
+
+          <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 24 }}>
+            <Button mode="outlined" onPress={() => router.back()}>
+              Back
+            </Button>
+            <Button
+              mode="contained"
+              disabled={!isValid}
+              onPress={() => router.push('/add-plant/step2')}
+            >
+              Next
+            </Button>
+          </View>
+        </ScrollView>
+      </TouchableWithoutFeedback>
     </KeyboardAvoidingView>
   );
 }

--- a/WeedGrowApp/app/add-plant/step2.tsx
+++ b/WeedGrowApp/app/add-plant/step2.tsx
@@ -1,6 +1,18 @@
 import React from 'react';
-import { ScrollView, KeyboardAvoidingView, Platform, View } from 'react-native';
-import { TextInput, Button, RadioButton } from 'react-native-paper';
+import {
+  ScrollView,
+  KeyboardAvoidingView,
+  Platform,
+  View,
+  TouchableWithoutFeedback,
+  Keyboard,
+} from 'react-native';
+import {
+  TextInput,
+  Button,
+  SegmentedButtons,
+  Menu,
+} from 'react-native-paper';
 import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
@@ -10,49 +22,112 @@ export default function Step2() {
   const router = useRouter();
   const { environment, potSize, sunlightExposure, plantedIn, setField } = usePlantForm();
 
+  const [potMenu, setPotMenu] = React.useState(false);
+  const [sunMenu, setSunMenu] = React.useState(false);
+
+  const inputStyle = {
+    backgroundColor: '#f5f5f5',
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    color: '#333',
+  } as const;
+
   return (
     <KeyboardAvoidingView
       style={{ flex: 1 }}
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
     >
-      <ScrollView contentContainerStyle={{ padding: 16 }}>
-        <StepIndicatorBar currentPosition={1} />
-        <RadioButton.Group
-          onValueChange={(val) => setField('environment', val as any)}
-          value={environment}
-        >
-          <RadioButton.Item label="Outdoor" value="outdoor" />
-          <RadioButton.Item label="Greenhouse" value="greenhouse" />
-          <RadioButton.Item label="Indoor" value="indoor" />
-        </RadioButton.Group>
-        <RadioButton.Group
-          onValueChange={(val) => setField('plantedIn', val as any)}
-          value={plantedIn}
-        >
-          <RadioButton.Item label="Pot" value="pot" />
-          <RadioButton.Item label="Ground" value="ground" />
-        </RadioButton.Group>
-        {plantedIn === 'pot' && (
-          <TextInput
-            label="Pot Size"
-            value={potSize}
-            onChangeText={(text) => setField('potSize', text)}
-            style={{ marginTop: 16 }}
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+        <ScrollView contentContainerStyle={{ padding: 24, gap: 16 }}>
+          <StepIndicatorBar currentPosition={1} />
+
+          <SegmentedButtons
+            value={environment}
+            onValueChange={(val) => setField('environment', val as any)}
+            buttons={[
+              { value: 'outdoor', label: 'Outdoor' },
+              { value: 'greenhouse', label: 'Greenhouse' },
+              { value: 'indoor', label: 'Indoor' },
+            ]}
           />
-        )}
-        <TextInput
-          label="Sunlight Exposure"
-          value={sunlightExposure}
-          onChangeText={(text) => setField('sunlightExposure', text)}
-          style={{ marginTop: 16 }}
-        />
-        <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 24 }}>
-          <Button mode="outlined" onPress={() => router.back()}>Back</Button>
-          <Button mode="contained" onPress={() => router.push('/add-plant/step3')}>
-            Next
-          </Button>
-        </View>
-      </ScrollView>
+
+          <SegmentedButtons
+            value={plantedIn}
+            onValueChange={(val) => setField('plantedIn', val as any)}
+            buttons={[
+              { value: 'pot', label: 'Pot' },
+              { value: 'ground', label: 'Ground' },
+            ]}
+          />
+
+          {plantedIn === 'pot' && (
+            <Menu
+              visible={potMenu}
+              onDismiss={() => setPotMenu(false)}
+              anchor={
+                <TextInput
+                  label="Pot Size"
+                  value={potSize}
+                  style={inputStyle}
+                  editable={false}
+                  right={<TextInput.Icon icon="menu-down" onPress={() => setPotMenu(true)} />}
+                />
+              }
+            >
+              {['1L', '5L', '10L', '20L', '50L'].map((size) => (
+                <Menu.Item
+                  key={size}
+                  onPress={() => {
+                    setField('potSize', size);
+                    setPotMenu(false);
+                  }}
+                  title={size}
+                />
+              ))}
+            </Menu>
+          )}
+
+          <Menu
+            visible={sunMenu}
+            onDismiss={() => setSunMenu(false)}
+            anchor={
+              <TextInput
+                label="Sunlight Exposure"
+                value={sunlightExposure}
+                style={inputStyle}
+                editable={false}
+                right={<TextInput.Icon icon="menu-down" onPress={() => setSunMenu(true)} />}
+              />
+            }
+          >
+            {[
+              'Full Sun (6–8+ hrs)',
+              'Partial Sun (3–6 hrs)',
+              'Mostly Shade (0–3 hrs)',
+              'Not Sure',
+            ].map((opt) => (
+              <Menu.Item
+                key={opt}
+                onPress={() => {
+                  setField('sunlightExposure', opt);
+                  setSunMenu(false);
+                }}
+                title={opt}
+              />
+            ))}
+          </Menu>
+
+          <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 24 }}>
+            <Button mode="outlined" onPress={() => router.back()}>
+              Back
+            </Button>
+            <Button mode="contained" onPress={() => router.push('/add-plant/step3')}>
+              Next
+            </Button>
+          </View>
+        </ScrollView>
+      </TouchableWithoutFeedback>
     </KeyboardAvoidingView>
   );
 }

--- a/WeedGrowApp/app/add-plant/step3.tsx
+++ b/WeedGrowApp/app/add-plant/step3.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
-import { ScrollView, KeyboardAvoidingView, Platform, View } from 'react-native';
+import {
+  ScrollView,
+  KeyboardAvoidingView,
+  Platform,
+  View,
+  TouchableWithoutFeedback,
+  Keyboard,
+  Image,
+} from 'react-native';
 import { TextInput, Button } from 'react-native-paper';
+import * as Location from 'expo-location';
 import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
@@ -12,42 +21,98 @@ export default function Step3() {
   const lat = location?.lat?.toString() ?? '';
   const lng = location?.lng?.toString() ?? '';
 
+  const [loading, setLoading] = React.useState(false);
+
+  const inputStyle = {
+    backgroundColor: '#f5f5f5',
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    color: '#333',
+  } as const;
+
+  const getLocation = async () => {
+    try {
+      setLoading(true);
+      const { status } = await Location.requestForegroundPermissionsAsync();
+      if (status !== 'granted') {
+        setLoading(false);
+        return;
+      }
+      const current = await Location.getCurrentPositionAsync({});
+      setField('location', {
+        lat: current.coords.latitude,
+        lng: current.coords.longitude,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <KeyboardAvoidingView
       style={{ flex: 1 }}
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
     >
-      <ScrollView contentContainerStyle={{ padding: 16 }}>
-        <StepIndicatorBar currentPosition={2} />
-        <TextInput
-          label="Latitude"
-          value={lat}
-          onChangeText={(text) =>
-            setField('location', { lat: parseFloat(text) || 0, lng: location?.lng || 0 })
-          }
-          style={{ marginTop: 16 }}
-        />
-        <TextInput
-          label="Longitude"
-          value={lng}
-          onChangeText={(text) =>
-            setField('location', { lat: location?.lat || 0, lng: parseFloat(text) || 0 })
-          }
-          style={{ marginTop: 16 }}
-        />
-        <TextInput
-          label="Location Nickname"
-          value={locationNickname}
-          onChangeText={(text) => setField('locationNickname', text)}
-          style={{ marginTop: 16 }}
-        />
-        <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 24 }}>
-          <Button mode="outlined" onPress={() => router.back()}>Back</Button>
-          <Button mode="contained" onPress={() => router.push('/add-plant/step4')}>
-            Next
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+        <ScrollView contentContainerStyle={{ padding: 24, gap: 16 }}>
+          <StepIndicatorBar currentPosition={2} />
+
+          <Button icon="crosshairs-gps" loading={loading} onPress={getLocation}>
+            📍 Use My Location
           </Button>
-        </View>
-      </ScrollView>
+
+          <View style={{ flexDirection: 'row', gap: 8 }}>
+            <TextInput
+              label="Latitude"
+              value={lat}
+              onChangeText={(text) =>
+                setField('location', {
+                  lat: parseFloat(text) || 0,
+                  lng: location?.lng || 0,
+                })
+              }
+              style={[inputStyle, { flex: 1 }]}
+            />
+            <TextInput
+              label="Longitude"
+              value={lng}
+              onChangeText={(text) =>
+                setField('location', {
+                  lat: location?.lat || 0,
+                  lng: parseFloat(text) || 0,
+                })
+              }
+              style={[inputStyle, { flex: 1 }]}
+            />
+          </View>
+
+          <TextInput
+            label="Location Nickname"
+            value={locationNickname}
+            onChangeText={(text) => setField('locationNickname', text)}
+            style={inputStyle}
+          />
+
+          {location && (
+            <Image
+              source={{
+                uri: `https://maps.googleapis.com/maps/api/staticmap?center=${lat},${lng}&zoom=15&size=600x300&markers=color:green|${lat},${lng}`,
+              }}
+              style={{ height: 150, borderRadius: 8 }}
+            />
+          )}
+
+          <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 24 }}>
+            <Button mode="outlined" onPress={() => router.back()}>
+              Back
+            </Button>
+            <Button mode="contained" onPress={() => router.push('/add-plant/step4')}>
+              Next
+            </Button>
+          </View>
+        </ScrollView>
+      </TouchableWithoutFeedback>
     </KeyboardAvoidingView>
   );
 }

--- a/WeedGrowApp/app/add-plant/step3.tsx
+++ b/WeedGrowApp/app/add-plant/step3.tsx
@@ -37,6 +37,11 @@ export default function Step3() {
       const { status } = await Location.requestForegroundPermissionsAsync();
       if (status !== 'granted') {
         setLoading(false);
+        Alert.alert(
+          'Permission Denied',
+          'Location permission is required to fetch your current location. Please enable it in your device settings.',
+          [{ text: 'OK' }]
+        );
         return;
       }
       const current = await Location.getCurrentPositionAsync({});

--- a/WeedGrowApp/app/add-plant/step4.tsx
+++ b/WeedGrowApp/app/add-plant/step4.tsx
@@ -1,6 +1,18 @@
 import React from 'react';
-import { ScrollView, KeyboardAvoidingView, Platform, View } from 'react-native';
-import { TextInput, Button } from 'react-native-paper';
+import {
+  ScrollView,
+  KeyboardAvoidingView,
+  Platform,
+  View,
+  TouchableWithoutFeedback,
+  Keyboard,
+} from 'react-native';
+import {
+  TextInput,
+  Button,
+  Chip,
+  Menu,
+} from 'react-native-paper';
 import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
@@ -10,44 +22,106 @@ export default function Step4() {
   const router = useRouter();
   const { wateringFrequency, fertilizer, pests, trainingTags, setField } = usePlantForm();
 
+  const [waterMenu, setWaterMenu] = React.useState(false);
+
+  const pestOptions = ['Spider Mites', 'Powdery Mildew', 'Aphids'];
+  const trainingOptions = ['LST', 'Topping', 'SCROG'];
+
+  const inputStyle = {
+    backgroundColor: '#f5f5f5',
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    color: '#333',
+  } as const;
+
   return (
     <KeyboardAvoidingView
       style={{ flex: 1 }}
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
     >
-      <ScrollView contentContainerStyle={{ padding: 16 }}>
-        <StepIndicatorBar currentPosition={3} />
-        <TextInput
-          label="Watering Frequency"
-          value={wateringFrequency}
-          onChangeText={(text) => setField('wateringFrequency', text)}
-          style={{ marginTop: 16 }}
-        />
-        <TextInput
-          label="Fertilizer"
-          value={fertilizer}
-          onChangeText={(text) => setField('fertilizer', text)}
-          style={{ marginTop: 16 }}
-        />
-        <TextInput
-          label="Pest History"
-          value={pests ? pests.join(', ') : ''}
-          onChangeText={(text) => setField('pests', text.split(',').map((s) => s.trim()))}
-          style={{ marginTop: 16 }}
-        />
-        <TextInput
-          label="Training Tags"
-          value={trainingTags ? trainingTags.join(', ') : ''}
-          onChangeText={(text) => setField('trainingTags', text.split(',').map((s) => s.trim()))}
-          style={{ marginTop: 16 }}
-        />
-        <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 24 }}>
-          <Button mode="outlined" onPress={() => router.back()}>Back</Button>
-          <Button mode="contained" onPress={() => router.push('/add-plant/step5')}>
-            Next
-          </Button>
-        </View>
-      </ScrollView>
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+        <ScrollView contentContainerStyle={{ padding: 24, gap: 16 }}>
+          <StepIndicatorBar currentPosition={3} />
+
+          <Menu
+            visible={waterMenu}
+            onDismiss={() => setWaterMenu(false)}
+            anchor={
+              <TextInput
+                label="Watering Frequency"
+                value={wateringFrequency}
+                style={inputStyle}
+                editable={false}
+                right={<TextInput.Icon icon="menu-down" onPress={() => setWaterMenu(true)} />}
+              />
+            }
+          >
+            {['Every day', 'Every 2 days', 'Every 3 days', 'Weekly'].map((opt) => (
+              <Menu.Item
+                key={opt}
+                onPress={() => {
+                  setField('wateringFrequency', opt);
+                  setWaterMenu(false);
+                }}
+                title={opt}
+              />
+            ))}
+          </Menu>
+
+          <TextInput
+            label="Fertilizer"
+            value={fertilizer}
+            onChangeText={(text) => setField('fertilizer', text)}
+            style={inputStyle}
+          />
+
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
+            {pestOptions.map((p) => (
+              <Chip
+                key={p}
+                selected={pests?.includes(p)}
+                onPress={() => {
+                  const arr = pests || [];
+                  setField(
+                    'pests',
+                    arr.includes(p) ? arr.filter((x) => x !== p) : [...arr, p]
+                  );
+                }}
+              >
+                {p}
+              </Chip>
+            ))}
+          </View>
+
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
+            {trainingOptions.map((t) => (
+              <Chip
+                key={t}
+                selected={trainingTags?.includes(t)}
+                onPress={() => {
+                  const arr = trainingTags || [];
+                  setField(
+                    'trainingTags',
+                    arr.includes(t) ? arr.filter((x) => x !== t) : [...arr, t]
+                  );
+                }}
+              >
+                {t}
+              </Chip>
+            ))}
+          </View>
+
+          <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 24 }}>
+            <Button mode="outlined" onPress={() => router.back()}>
+              Back
+            </Button>
+            <Button mode="contained" onPress={() => router.push('/add-plant/step5')}>
+              Next
+            </Button>
+          </View>
+        </ScrollView>
+      </TouchableWithoutFeedback>
     </KeyboardAvoidingView>
   );
 }

--- a/WeedGrowApp/app/add-plant/step5.tsx
+++ b/WeedGrowApp/app/add-plant/step5.tsx
@@ -55,7 +55,11 @@ export default function Step5() {
           </View>
 
           {imageUri ? (
-            <Image source={{ uri: imageUri }} style={{ height: 200, borderRadius: 8 }} />
+            <Image
+              source={{ uri: imageUri }}
+              style={{ height: 200, width: 200, borderRadius: 8 }}
+              resizeMode="cover"
+            />
           ) : null}
 
           <TextInput

--- a/WeedGrowApp/app/add-plant/step5.tsx
+++ b/WeedGrowApp/app/add-plant/step5.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
-import { ScrollView, KeyboardAvoidingView, Platform, View } from 'react-native';
+import {
+  ScrollView,
+  KeyboardAvoidingView,
+  Platform,
+  View,
+  TouchableWithoutFeedback,
+  Keyboard,
+  Image,
+} from 'react-native';
 import { TextInput, Button } from 'react-native-paper';
+import * as ImagePicker from 'expo-image-picker';
 import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
@@ -10,33 +19,64 @@ export default function Step5() {
   const router = useRouter();
   const { notes, imageUri, setField } = usePlantForm();
 
+  const inputStyle = {
+    backgroundColor: '#f5f5f5',
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    color: '#333',
+  } as const;
+
+  const pickImage = async (fromCamera: boolean) => {
+    const result = fromCamera
+      ? await ImagePicker.launchCameraAsync({ mediaTypes: ImagePicker.MediaTypeOptions.Images })
+      : await ImagePicker.launchImageLibraryAsync({ mediaTypes: ImagePicker.MediaTypeOptions.Images });
+    if (!result.canceled) {
+      setField('imageUri', result.assets[0].uri);
+    }
+  };
+
   return (
     <KeyboardAvoidingView
       style={{ flex: 1 }}
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
     >
-      <ScrollView contentContainerStyle={{ padding: 16 }}>
-        <StepIndicatorBar currentPosition={4} />
-        <TextInput
-          label="Image URI"
-          value={imageUri}
-          onChangeText={(text) => setField('imageUri', text)}
-          style={{ marginTop: 16 }}
-        />
-        <TextInput
-          label="Notes"
-          value={notes}
-          onChangeText={(text) => setField('notes', text)}
-          multiline
-          style={{ marginTop: 16 }}
-        />
-        <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 24 }}>
-          <Button mode="outlined" onPress={() => router.back()}>Back</Button>
-          <Button mode="contained" onPress={() => router.push('/add-plant/review')}>
-            Next
-          </Button>
-        </View>
-      </ScrollView>
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+        <ScrollView contentContainerStyle={{ padding: 24, gap: 16 }}>
+          <StepIndicatorBar currentPosition={4} />
+
+          <View style={{ flexDirection: 'row', gap: 8 }}>
+            <Button mode="outlined" icon="camera" onPress={() => pickImage(true)}>
+              Take Photo
+            </Button>
+            <Button mode="outlined" icon="image" onPress={() => pickImage(false)}>
+              Choose from Gallery
+            </Button>
+          </View>
+
+          {imageUri ? (
+            <Image source={{ uri: imageUri }} style={{ height: 200, borderRadius: 8 }} />
+          ) : null}
+
+          <TextInput
+            label="Notes"
+            value={notes}
+            onChangeText={(text) => setField('notes', text)}
+            multiline
+            placeholder="Add any observations here..."
+            style={[inputStyle, { height: 120 }]}
+          />
+
+          <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 24 }}>
+            <Button mode="outlined" onPress={() => router.back()}>
+              Back
+            </Button>
+            <Button mode="contained" onPress={() => router.push('/add-plant/review')}>
+              Next
+            </Button>
+          </View>
+        </ScrollView>
+      </TouchableWithoutFeedback>
     </KeyboardAvoidingView>
   );
 }


### PR DESCRIPTION
## Summary
- refine Basic Info screen with segmented buttons and dropdown
- tidy Environment step with segmented buttons and selects
- add location fetch, map preview and better layout
- switch care step inputs to menus and chips
- add image picker and notes styling
- show clean summary card on review

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e5927e288330a49cc30a2c5755e9