### PR TITLE
UI polish for add plant flow

### DIFF
--- a/WeedGrowApp/app/add-plant/review.tsx
+++ b/WeedGrowApp/app/add-plant/review.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ScrollView, View, Image } from 'react-native';
+import { ScrollView, View, Image, StyleSheet } from 'react-native';
 import { Button, Card, Text, Divider } from 'react-native-paper';
 import { useRouter } from 'expo-router';
 
@@ -16,6 +16,10 @@ export default function Review() {
     router.replace('/plants');
   };
 
+  const styles = StyleSheet.create({
+    sectionTitle: { fontWeight: 'bold', marginTop: 16, marginBottom: 8, fontSize: 16 },
+  });
+
   return (
     <ScrollView contentContainerStyle={{ padding: 24, gap: 16 }}>
       <StepIndicatorBar currentPosition={4} />
@@ -24,6 +28,7 @@ export default function Review() {
         <Card.Title title="Review Plant" />
         <Card.Content>
           <View style={{ gap: 8 }}>
+            <Text style={styles.sectionTitle}>Growth Info</Text>
             <View>
               <Text variant="labelLarge">Name</Text>
               <Text>{form.name}</Text>
@@ -38,7 +43,9 @@ export default function Review() {
               <Text variant="labelLarge">Growth Stage</Text>
               <Text>{form.growthStage}</Text>
             </View>
+
             <Divider />
+            <Text style={styles.sectionTitle}>Environment</Text>
             <View>
               <Text variant="labelLarge">Environment</Text>
               <Text>{form.environment}</Text>
@@ -90,49 +97,52 @@ export default function Review() {
                 </View>
               </>
             )}
+
+            <Divider />
+            <Text style={styles.sectionTitle}>Care</Text>
             {form.wateringFrequency && (
               <>
-                <Divider />
                 <View>
                   <Text variant="labelLarge">Watering</Text>
                   <Text>{form.wateringFrequency}</Text>
                 </View>
+                <Divider />
               </>
             )}
             {form.fertilizer && (
               <>
-                <Divider />
                 <View>
                   <Text variant="labelLarge">Fertilizer</Text>
                   <Text>{form.fertilizer}</Text>
                 </View>
+                <Divider />
               </>
             )}
             {form.pests && form.pests.length > 0 && (
               <>
-                <Divider />
                 <View>
                   <Text variant="labelLarge">Pests</Text>
                   <Text>{form.pests.join(', ')}</Text>
                 </View>
+                <Divider />
               </>
             )}
             {form.trainingTags && form.trainingTags.length > 0 && (
               <>
-                <Divider />
                 <View>
                   <Text variant="labelLarge">Training</Text>
                   <Text>{form.trainingTags.join(', ')}</Text>
                 </View>
+                <Divider />
               </>
             )}
             {form.notes && (
               <>
-                <Divider />
                 <View>
                   <Text variant="labelLarge">Notes</Text>
                   <Text>{form.notes}</Text>
                 </View>
+                <Divider />
               </>
             )}
             {form.imageUri && (

--- a/WeedGrowApp/app/add-plant/step1.tsx
+++ b/WeedGrowApp/app/add-plant/step1.tsx
@@ -10,9 +10,9 @@ import {
 import {
   TextInput,
   Button,
-  SegmentedButtons,
   Text,
   Menu,
+  RadioButton,
 } from 'react-native-paper';
 import { useRouter } from 'expo-router';
 
@@ -25,6 +25,8 @@ export default function Step1() {
 
   const isValid = name.trim().length > 0;
   const [strainMenu, setStrainMenu] = React.useState(false);
+  const [strainSearch, setStrainSearch] = React.useState('');
+  const strains = ['Sativa', 'Indica', 'Hybrid'];
 
   const inputStyle = {
     backgroundColor: '#f5f5f5',
@@ -42,7 +44,9 @@ export default function Step1() {
       <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
         <ScrollView contentContainerStyle={{ padding: 24, gap: 16 }}>
           <StepIndicatorBar currentPosition={0} />
-          <Text variant="titleLarge">🌱 Let’s start with the basics</Text>
+          <Text variant="titleLarge" style={{ textAlign: 'center', marginTop: 8 }}>
+            🌱 Let’s start with the basics
+          </Text>
 
           <TextInput
             label="Plant Name"
@@ -57,8 +61,8 @@ export default function Step1() {
             anchor={
               <TextInput
                 label="Strain"
-                value={strain}
-                onChangeText={(text) => setField('strain', text)}
+                value={strain || 'Unknown'}
+                editable={false}
                 style={inputStyle}
                 right={
                   <TextInput.Icon
@@ -69,28 +73,36 @@ export default function Step1() {
               />
             }
           >
-            {['Unknown', 'Sativa', 'Indica', 'Hybrid'].map((opt) => (
+            <TextInput
+              placeholder="Search..."
+              value={strainSearch}
+              onChangeText={setStrainSearch}
+              style={{ margin: 8 }}
+            />
+            {["Unknown", ...strains.filter((s) =>
+              s.toLowerCase().includes(strainSearch.toLowerCase())
+            )].map((opt) => (
               <Menu.Item
                 key={opt}
                 onPress={() => {
                   setField('strain', opt);
                   setStrainMenu(false);
+                  setStrainSearch('');
                 }}
                 title={opt}
               />
             ))}
           </Menu>
 
-          <SegmentedButtons
-            value={growthStage}
+          <RadioButton.Group
             onValueChange={(val) => setField('growthStage', val as any)}
-            buttons={[
-              { value: 'germination', label: 'Germination' },
-              { value: 'seedling', label: 'Seedling' },
-              { value: 'vegetative', label: 'Vegetative' },
-              { value: 'flowering', label: 'Flowering' },
-            ]}
-          />
+            value={growthStage}
+          >
+            <RadioButton.Item label="Germination" value="germination" position="leading" />
+            <RadioButton.Item label="Seedling" value="seedling" position="leading" />
+            <RadioButton.Item label="Vegetative" value="vegetative" position="leading" />
+            <RadioButton.Item label="Flowering" value="flowering" position="leading" />
+          </RadioButton.Group>
 
           <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 24 }}>
             <Button mode="outlined" onPress={() => router.back()}>

--- a/WeedGrowApp/app/add-plant/step2.tsx
+++ b/WeedGrowApp/app/add-plant/step2.tsx
@@ -10,7 +10,6 @@ import {
 import {
   TextInput,
   Button,
-  SegmentedButtons,
   Menu,
 } from 'react-native-paper';
 import { useRouter } from 'expo-router';
@@ -42,24 +41,29 @@ export default function Step2() {
         <ScrollView contentContainerStyle={{ padding: 24, gap: 16 }}>
           <StepIndicatorBar currentPosition={1} />
 
-          <SegmentedButtons
-            value={environment}
-            onValueChange={(val) => setField('environment', val as any)}
-            buttons={[
-              { value: 'outdoor', label: 'Outdoor' },
-              { value: 'greenhouse', label: 'Greenhouse' },
-              { value: 'indoor', label: 'Indoor' },
-            ]}
-          />
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
+            {['outdoor', 'greenhouse', 'indoor'].map((opt) => (
+              <Button
+                key={opt}
+                mode={environment === opt ? 'contained' : 'outlined'}
+                onPress={() => setField('environment', opt as any)}
+              >
+                {opt.charAt(0).toUpperCase() + opt.slice(1)}
+              </Button>
+            ))}
+          </View>
 
-          <SegmentedButtons
-            value={plantedIn}
-            onValueChange={(val) => setField('plantedIn', val as any)}
-            buttons={[
-              { value: 'pot', label: 'Pot' },
-              { value: 'ground', label: 'Ground' },
-            ]}
-          />
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
+            {['pot', 'ground'].map((opt) => (
+              <Button
+                key={opt}
+                mode={plantedIn === opt ? 'contained' : 'outlined'}
+                onPress={() => setField('plantedIn', opt as any)}
+              >
+                {opt === 'pot' ? 'Pot' : 'Ground'}
+              </Button>
+            ))}
+          </View>
 
           {plantedIn === 'pot' && (
             <Menu
@@ -101,12 +105,7 @@ export default function Step2() {
               />
             }
           >
-            {[
-              'Full Sun (6–8+ hrs)',
-              'Partial Sun (3–6 hrs)',
-              'Mostly Shade (0–3 hrs)',
-              'Not Sure',
-            ].map((opt) => (
+            {['Full Sun', 'Partial Sun', 'Mostly Shade', 'Not Sure'].map((opt) => (
               <Menu.Item
                 key={opt}
                 onPress={() => {

--- a/WeedGrowApp/app/add-plant/step3.tsx
+++ b/WeedGrowApp/app/add-plant/step3.tsx
@@ -63,34 +63,47 @@ export default function Step3() {
         <ScrollView contentContainerStyle={{ padding: 24, gap: 16 }}>
           <StepIndicatorBar currentPosition={2} />
 
-          <Button icon="crosshairs-gps" loading={loading} onPress={getLocation}>
+          <Button
+            icon="crosshairs-gps"
+            loading={loading}
+            onPress={getLocation}
+            style={{ marginBottom: 8, marginTop: 8 }}
+          >
             📍 Use My Location
           </Button>
 
-          <View style={{ flexDirection: 'row', gap: 8 }}>
+          {location ? (
             <TextInput
-              label="Latitude"
-              value={lat}
-              onChangeText={(text) =>
-                setField('location', {
-                  lat: parseFloat(text) || 0,
-                  lng: location?.lng || 0,
-                })
-              }
-              style={[inputStyle, { flex: 1 }]}
+              value={`📍 Location: ${lat}, ${lng} (from GPS)`}
+              editable={false}
+              style={inputStyle}
             />
-            <TextInput
-              label="Longitude"
-              value={lng}
-              onChangeText={(text) =>
-                setField('location', {
-                  lat: location?.lat || 0,
-                  lng: parseFloat(text) || 0,
-                })
-              }
-              style={[inputStyle, { flex: 1 }]}
-            />
-          </View>
+          ) : (
+            <View style={{ flexDirection: 'row', gap: 8 }}>
+              <TextInput
+                label="Latitude"
+                value={lat}
+                onChangeText={(text) =>
+                  setField('location', {
+                    lat: parseFloat(text) || 0,
+                    lng: location?.lng || 0,
+                  })
+                }
+                style={[inputStyle, { flex: 1 }]}
+              />
+              <TextInput
+                label="Longitude"
+                value={lng}
+                onChangeText={(text) =>
+                  setField('location', {
+                    lat: location?.lat || 0,
+                    lng: parseFloat(text) || 0,
+                  })
+                }
+                style={[inputStyle, { flex: 1 }]}
+              />
+            </View>
+          )}
 
           <TextInput
             label="Location Nickname"

--- a/WeedGrowApp/app/add-plant/step4.tsx
+++ b/WeedGrowApp/app/add-plant/step4.tsx
@@ -6,12 +6,14 @@ import {
   View,
   TouchableWithoutFeedback,
   Keyboard,
+  StyleSheet,
 } from 'react-native';
 import {
   TextInput,
   Button,
   Chip,
   Menu,
+  Text,
 } from 'react-native-paper';
 import { useRouter } from 'expo-router';
 
@@ -34,6 +36,10 @@ export default function Step4() {
     fontSize: 16,
     color: '#333',
   } as const;
+
+  const styles = StyleSheet.create({
+    sectionTitle: { fontWeight: 'bold', marginTop: 16, marginBottom: 8, fontSize: 16 },
+  });
 
   return (
     <KeyboardAvoidingView
@@ -76,6 +82,7 @@ export default function Step4() {
             style={inputStyle}
           />
 
+          <Text style={styles.sectionTitle}>Pest History</Text>
           <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
             {pestOptions.map((p) => (
               <Chip
@@ -94,6 +101,7 @@ export default function Step4() {
             ))}
           </View>
 
+          <Text style={styles.sectionTitle}>Training Techniques</Text>
           <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
             {trainingOptions.map((t) => (
               <Chip

--- a/WeedGrowApp/app/add-plant/step5.tsx
+++ b/WeedGrowApp/app/add-plant/step5.tsx
@@ -8,7 +8,7 @@ import {
   Keyboard,
   Image,
 } from 'react-native';
-import { TextInput, Button } from 'react-native-paper';
+import { TextInput, Button, Snackbar } from 'react-native-paper';
 import * as ImagePicker from 'expo-image-picker';
 import { useRouter } from 'expo-router';
 
@@ -18,6 +18,7 @@ import { usePlantForm } from '@/stores/usePlantForm';
 export default function Step5() {
   const router = useRouter();
   const { notes, imageUri, setField } = usePlantForm();
+  const [snackVisible, setSnackVisible] = React.useState(false);
 
   const inputStyle = {
     backgroundColor: '#f5f5f5',
@@ -33,6 +34,7 @@ export default function Step5() {
       : await ImagePicker.launchImageLibraryAsync({ mediaTypes: ImagePicker.MediaTypeOptions.Images });
     if (!result.canceled) {
       setField('imageUri', result.assets[0].uri);
+      setSnackVisible(true);
     }
   };
 
@@ -63,13 +65,17 @@ export default function Step5() {
           ) : null}
 
           <TextInput
-            label="Notes"
+            label="Observations (optional)"
             value={notes}
             onChangeText={(text) => setField('notes', text)}
             multiline
             placeholder="Add any observations here..."
             style={[inputStyle, { height: 120 }]}
           />
+
+          <Snackbar visible={snackVisible} onDismiss={() => setSnackVisible(false)}>
+            Photo selected
+          </Snackbar>
 
           <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 24 }}>
             <Button mode="outlined" onPress={() => router.back()}>

--- a/WeedGrowApp/components/StepIndicatorBar.tsx
+++ b/WeedGrowApp/components/StepIndicatorBar.tsx
@@ -1,5 +1,7 @@
 import StepIndicator from 'react-native-step-indicator';
 import React from 'react';
+import { View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const labels = ['Basic Info', 'Environment', 'Location', 'Care', 'Photo'];
 
@@ -28,12 +30,15 @@ const customStyles = {
 };
 
 export default function StepIndicatorBar({ currentPosition }: { currentPosition: number }) {
+  const insets = useSafeAreaInsets();
   return (
-    <StepIndicator
-      customStyles={customStyles}
-      currentPosition={currentPosition}
-      labels={labels}
-      stepCount={labels.length}
-    />
+    <View style={{ marginTop: insets.top + 8, marginBottom: 16 }}>
+      <StepIndicator
+        customStyles={customStyles}
+        currentPosition={currentPosition}
+        labels={labels}
+        stepCount={labels.length}
+      />
+    </View>
   );
 }


### PR DESCRIPTION
## Summary
- style `StepIndicatorBar` with safe area margin
- refine basic info page with radio buttons and searchable strain menu
- use button grids on environment step and update dropdown options
- show GPS summary and cleanup location step layout
- add section headers for pest history and training techniques
- improve photo step with snackbar feedback and optional notes label
- group review details under clear headings

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ef5eb490833086ee642552824d5b