### PR TITLE
Align step screens with shared dark theme

### DIFF
--- a/WeedGrowApp/app/_layout.tsx
+++ b/WeedGrowApp/app/_layout.tsx
@@ -1,6 +1,7 @@
 import { Slot } from 'expo-router';
 import { PaperProvider, MD3DarkTheme } from 'react-native-paper';
 import { SafeAreaView } from 'react-native';
+import { Colors } from '@/constants/Colors';
 import { useFonts } from 'expo-font';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
@@ -19,13 +20,13 @@ export default function RootLayout() {
     ...MD3DarkTheme,
     colors: {
       ...MD3DarkTheme.colors,
-      primary: '#00c853',
+      primary: Colors.dark.tint,
     },
   };
 
   return (
     <PaperProvider theme={theme}>
-      <SafeAreaView style={{ flex: 1, backgroundColor: '#151718' }}>
+      <SafeAreaView style={{ flex: 1, backgroundColor: Colors.dark.background }}>
         <Slot />
         <StatusBar style="light" />
       </SafeAreaView>

--- a/WeedGrowApp/app/add-plant/step1.tsx
+++ b/WeedGrowApp/app/add-plant/step1.tsx
@@ -29,11 +29,9 @@ export default function Step1() {
   const strains = ['Sativa', 'Indica', 'Hybrid'];
 
   const inputStyle = {
-    backgroundColor: '#f5f5f5',
     borderRadius: 8,
     padding: 12,
     fontSize: 16,
-    color: '#333',
   } as const;
 
   return (

--- a/WeedGrowApp/app/add-plant/step2.tsx
+++ b/WeedGrowApp/app/add-plant/step2.tsx
@@ -25,11 +25,9 @@ export default function Step2() {
   const [sunMenu, setSunMenu] = React.useState(false);
 
   const inputStyle = {
-    backgroundColor: '#f5f5f5',
     borderRadius: 8,
     padding: 12,
     fontSize: 16,
-    color: '#333',
   } as const;
 
   return (

--- a/WeedGrowApp/app/add-plant/step3.tsx
+++ b/WeedGrowApp/app/add-plant/step3.tsx
@@ -24,11 +24,9 @@ export default function Step3() {
   const [loading, setLoading] = React.useState(false);
 
   const inputStyle = {
-    backgroundColor: '#f5f5f5',
     borderRadius: 8,
     padding: 12,
     fontSize: 16,
-    color: '#333',
   } as const;
 
   const getLocation = async () => {

--- a/WeedGrowApp/app/add-plant/step4.tsx
+++ b/WeedGrowApp/app/add-plant/step4.tsx
@@ -30,11 +30,9 @@ export default function Step4() {
   const trainingOptions = ['LST', 'Topping', 'SCROG'];
 
   const inputStyle = {
-    backgroundColor: '#f5f5f5',
     borderRadius: 8,
     padding: 12,
     fontSize: 16,
-    color: '#333',
   } as const;
 
   const styles = StyleSheet.create({

--- a/WeedGrowApp/app/add-plant/step5.tsx
+++ b/WeedGrowApp/app/add-plant/step5.tsx
@@ -21,11 +21,9 @@ export default function Step5() {
   const [snackVisible, setSnackVisible] = React.useState(false);
 
   const inputStyle = {
-    backgroundColor: '#f5f5f5',
     borderRadius: 8,
     padding: 12,
     fontSize: 16,
-    color: '#333',
   } as const;
 
   const pickImage = async (fromCamera: boolean) => {

--- a/WeedGrowApp/components/StepIndicatorBar.tsx
+++ b/WeedGrowApp/components/StepIndicatorBar.tsx
@@ -2,35 +2,39 @@ import StepIndicator from 'react-native-step-indicator';
 import React from 'react';
 import { View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 const labels = ['Basic Info', 'Environment', 'Location', 'Care', 'Photo'];
 
-const customStyles = {
-  stepIndicatorSize: 25,
-  currentStepIndicatorSize: 30,
-  separatorStrokeWidth: 2,
-  currentStepStrokeWidth: 3,
-  stepStrokeCurrentColor: '#00c853',
-  stepStrokeWidth: 2,
-  stepStrokeFinishedColor: '#00c853',
-  stepStrokeUnFinishedColor: '#aaaaaa',
-  separatorFinishedColor: '#00c853',
-  separatorUnFinishedColor: '#aaaaaa',
-  stepIndicatorFinishedColor: '#00c853',
-  stepIndicatorUnFinishedColor: '#ffffff',
-  stepIndicatorCurrentColor: '#00c853',
-  stepIndicatorLabelFontSize: 13,
-  currentStepIndicatorLabelFontSize: 13,
-  stepIndicatorLabelCurrentColor: '#ffffff',
-  stepIndicatorLabelFinishedColor: '#ffffff',
-  stepIndicatorLabelUnFinishedColor: '#aaaaaa',
-  labelColor: '#999999',
-  labelSize: 11,
-  currentStepLabelColor: '#00c853',
-};
-
 export default function StepIndicatorBar({ currentPosition }: { currentPosition: number }) {
   const insets = useSafeAreaInsets();
+  const theme = useColorScheme() ?? 'dark';
+
+  const customStyles = {
+    stepIndicatorSize: 25,
+    currentStepIndicatorSize: 30,
+    separatorStrokeWidth: 2,
+    currentStepStrokeWidth: 3,
+    stepStrokeCurrentColor: Colors[theme].tint,
+    stepStrokeWidth: 2,
+    stepStrokeFinishedColor: Colors[theme].tint,
+    stepStrokeUnFinishedColor: Colors[theme].gray,
+    separatorFinishedColor: Colors[theme].tint,
+    separatorUnFinishedColor: Colors[theme].gray,
+    stepIndicatorFinishedColor: Colors[theme].tint,
+    stepIndicatorUnFinishedColor: Colors[theme].white,
+    stepIndicatorCurrentColor: Colors[theme].tint,
+    stepIndicatorLabelFontSize: 13,
+    currentStepIndicatorLabelFontSize: 13,
+    stepIndicatorLabelCurrentColor: Colors[theme].white,
+    stepIndicatorLabelFinishedColor: Colors[theme].white,
+    stepIndicatorLabelUnFinishedColor: Colors[theme].gray,
+    labelColor: Colors[theme].label,
+    labelSize: 11,
+    currentStepLabelColor: Colors[theme].tint,
+  } as const;
+
   return (
     <View style={{ marginTop: insets.top + 8, marginBottom: 16 }}>
       <StepIndicator

--- a/WeedGrowApp/components/ThemedText.tsx
+++ b/WeedGrowApp/components/ThemedText.tsx
@@ -1,6 +1,7 @@
 import { StyleSheet, Text, type TextProps } from 'react-native';
 
 import { useThemeColor } from '@/hooks/useThemeColor';
+import { Colors } from '@/constants/Colors';
 
 export type ThemedTextProps = TextProps & {
   lightColor?: string;
@@ -55,6 +56,6 @@ const styles = StyleSheet.create({
   link: {
     lineHeight: 30,
     fontSize: 16,
-    color: '#00c853',
+    color: Colors.dark.tint,
   },
 });

--- a/WeedGrowApp/components/ThemedText.tsx
+++ b/WeedGrowApp/components/ThemedText.tsx
@@ -56,6 +56,6 @@ const styles = StyleSheet.create({
   link: {
     lineHeight: 30,
     fontSize: 16,
-    color: Colors.dark.tint,
+    color: useThemeColor({ light: Colors.light.tint, dark: Colors.dark.tint }, 'link'),
   },
 });

--- a/WeedGrowApp/constants/Colors.ts
+++ b/WeedGrowApp/constants/Colors.ts
@@ -5,6 +5,9 @@
 
 const tintColorLight = '#00c853';
 const tintColorDark = '#00c853';
+const grayColor = '#aaaaaa';
+const labelColor = '#999999';
+const whiteColor = '#ffffff';
 
 export const Colors = {
   light: {
@@ -14,6 +17,9 @@ export const Colors = {
     icon: tintColorLight,
     tabIconDefault: tintColorLight,
     tabIconSelected: tintColorLight,
+    gray: grayColor,
+    label: labelColor,
+    white: whiteColor,
   },
   dark: {
     text: '#ECEDEE',
@@ -22,5 +28,8 @@ export const Colors = {
     icon: tintColorDark,
     tabIconDefault: tintColorDark,
     tabIconSelected: tintColorDark,
+    gray: grayColor,
+    label: labelColor,
+    white: whiteColor,
   },
 };


### PR DESCRIPTION
## Summary
- centralize gray and label colors in `Colors.ts`
- update `StepIndicatorBar` to pull colors from the shared palette
- reference shared colors in `ThemedText` link style
- apply shared theme colors in the root layout
- remove hard‑coded colors from add-plant step screens

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f505809c8330b467068769be9590