### PR TITLE
Add dark background to plant step screens

### DIFF
--- a/WeedGrowApp/app/add-plant/review.tsx
+++ b/WeedGrowApp/app/add-plant/review.tsx
@@ -5,10 +5,13 @@ import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 export default function Review() {
   const router = useRouter();
   const form = usePlantForm();
+  const theme = useColorScheme() ?? 'dark';
 
   const save = () => {
     console.log('Plant saved:', { ...form });
@@ -21,7 +24,9 @@ export default function Review() {
   });
 
   return (
-    <ScrollView contentContainerStyle={{ padding: 24, gap: 16 }}>
+    <ScrollView
+      style={{ flex: 1, backgroundColor: Colors[theme].background }}
+      contentContainerStyle={{ padding: 24, gap: 16 }}>
       <StepIndicatorBar currentPosition={4} />
 
       <Card>

--- a/WeedGrowApp/app/add-plant/step1.tsx
+++ b/WeedGrowApp/app/add-plant/step1.tsx
@@ -18,10 +18,13 @@ import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 export default function Step1() {
   const router = useRouter();
   const { name, strain, growthStage, setField } = usePlantForm();
+  const theme = useColorScheme() ?? 'dark';
 
   const isValid = name.trim().length > 0;
   const [strainMenu, setStrainMenu] = React.useState(false);
@@ -40,7 +43,9 @@ export default function Step1() {
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
     >
       <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-        <ScrollView contentContainerStyle={{ padding: 24, gap: 16 }}>
+        <ScrollView
+          style={{ flex: 1, backgroundColor: Colors[theme].background }}
+          contentContainerStyle={{ padding: 24, gap: 16 }}>
           <StepIndicatorBar currentPosition={0} />
           <Text variant="titleLarge" style={{ textAlign: 'center', marginTop: 8 }}>
             🌱 Let’s start with the basics

--- a/WeedGrowApp/app/add-plant/step2.tsx
+++ b/WeedGrowApp/app/add-plant/step2.tsx
@@ -16,10 +16,13 @@ import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 export default function Step2() {
   const router = useRouter();
   const { environment, potSize, sunlightExposure, plantedIn, setField } = usePlantForm();
+  const theme = useColorScheme() ?? 'dark';
 
   const [potMenu, setPotMenu] = React.useState(false);
   const [sunMenu, setSunMenu] = React.useState(false);
@@ -36,7 +39,9 @@ export default function Step2() {
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
     >
       <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-        <ScrollView contentContainerStyle={{ padding: 24, gap: 16 }}>
+        <ScrollView
+          style={{ flex: 1, backgroundColor: Colors[theme].background }}
+          contentContainerStyle={{ padding: 24, gap: 16 }}>
           <StepIndicatorBar currentPosition={1} />
 
           <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>

--- a/WeedGrowApp/app/add-plant/step3.tsx
+++ b/WeedGrowApp/app/add-plant/step3.tsx
@@ -14,10 +14,13 @@ import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 export default function Step3() {
   const router = useRouter();
   const { location, locationNickname, setField } = usePlantForm();
+  const theme = useColorScheme() ?? 'dark';
   const lat = location?.lat?.toString() ?? '';
   const lng = location?.lng?.toString() ?? '';
 
@@ -58,7 +61,9 @@ export default function Step3() {
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
     >
       <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-        <ScrollView contentContainerStyle={{ padding: 24, gap: 16 }}>
+        <ScrollView
+          style={{ flex: 1, backgroundColor: Colors[theme].background }}
+          contentContainerStyle={{ padding: 24, gap: 16 }}>
           <StepIndicatorBar currentPosition={2} />
 
           <Button

--- a/WeedGrowApp/app/add-plant/step4.tsx
+++ b/WeedGrowApp/app/add-plant/step4.tsx
@@ -19,10 +19,13 @@ import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 export default function Step4() {
   const router = useRouter();
   const { wateringFrequency, fertilizer, pests, trainingTags, setField } = usePlantForm();
+  const theme = useColorScheme() ?? 'dark';
 
   const [waterMenu, setWaterMenu] = React.useState(false);
 
@@ -45,7 +48,9 @@ export default function Step4() {
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
     >
       <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-        <ScrollView contentContainerStyle={{ padding: 24, gap: 16 }}>
+        <ScrollView
+          style={{ flex: 1, backgroundColor: Colors[theme].background }}
+          contentContainerStyle={{ padding: 24, gap: 16 }}>
           <StepIndicatorBar currentPosition={3} />
 
           <Menu

--- a/WeedGrowApp/app/add-plant/step5.tsx
+++ b/WeedGrowApp/app/add-plant/step5.tsx
@@ -14,11 +14,14 @@ import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 export default function Step5() {
   const router = useRouter();
   const { notes, imageUri, setField } = usePlantForm();
   const [snackVisible, setSnackVisible] = React.useState(false);
+  const theme = useColorScheme() ?? 'dark';
 
   const inputStyle = {
     borderRadius: 8,
@@ -42,7 +45,9 @@ export default function Step5() {
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
     >
       <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-        <ScrollView contentContainerStyle={{ padding: 24, gap: 16 }}>
+        <ScrollView
+          style={{ flex: 1, backgroundColor: Colors[theme].background }}
+          contentContainerStyle={{ padding: 24, gap: 16 }}>
           <StepIndicatorBar currentPosition={4} />
 
           <View style={{ flexDirection: 'row', gap: 8 }}>


### PR DESCRIPTION
## Summary
- ensure add plant steps respect dark theme by setting scrollview background

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f76d52748330a74a71d1207c7da3