### PR TITLE
Improve Add Plant screens UI

### DIFF
--- a/WeedGrowApp/app/_layout.tsx
+++ b/WeedGrowApp/app/_layout.tsx
@@ -1,6 +1,6 @@
 import { Slot } from 'expo-router';
 import { PaperProvider, MD3DarkTheme } from 'react-native-paper';
-import { SafeAreaView } from 'react-native';
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { Colors } from '@/constants/Colors';
 import { useFonts } from 'expo-font';
 import { StatusBar } from 'expo-status-bar';
@@ -25,11 +25,13 @@ export default function RootLayout() {
   };
 
   return (
-    <PaperProvider theme={theme}>
-      <SafeAreaView style={{ flex: 1, backgroundColor: Colors.dark.background }}>
-        <Slot />
-        <StatusBar style="light" />
-      </SafeAreaView>
-    </PaperProvider>
+    <SafeAreaProvider>
+      <PaperProvider theme={theme}>
+        <SafeAreaView style={{ flex: 1, backgroundColor: Colors.dark.background }}>
+          <Slot />
+          <StatusBar style="light" />
+        </SafeAreaView>
+      </PaperProvider>
+    </SafeAreaProvider>
   );
 }

--- a/WeedGrowApp/app/add-plant/review.tsx
+++ b/WeedGrowApp/app/add-plant/review.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ScrollView, View, Image, StyleSheet } from 'react-native';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Button, Card, Text, Divider } from 'react-native-paper';
 import { useRouter } from 'expo-router';
 
@@ -12,6 +13,7 @@ export default function Review() {
   const router = useRouter();
   const form = usePlantForm();
   const theme = useColorScheme() ?? 'dark';
+  const insets = useSafeAreaInsets();
 
   const save = () => {
     console.log('Plant saved:', { ...form });
@@ -24,9 +26,10 @@ export default function Review() {
   });
 
   return (
-    <ScrollView
-      style={{ flex: 1, backgroundColor: Colors[theme].background }}
-      contentContainerStyle={{ padding: 24, gap: 16 }}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: Colors[theme].background, paddingTop: insets.top + 16 }}>
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 24, gap: 16 }}>
       <StepIndicatorBar currentPosition={4} />
 
       <Card>
@@ -169,5 +172,6 @@ export default function Review() {
         </Button>
       </View>
     </ScrollView>
+  </SafeAreaView>
   );
 }

--- a/WeedGrowApp/app/add-plant/step1.tsx
+++ b/WeedGrowApp/app/add-plant/step1.tsx
@@ -7,12 +7,13 @@ import {
   TouchableWithoutFeedback,
   Keyboard,
 } from 'react-native';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   TextInput,
   Button,
   Text,
   Menu,
-  RadioButton,
+  SegmentedButtons,
 } from 'react-native-paper';
 import { useRouter } from 'expo-router';
 
@@ -25,6 +26,7 @@ export default function Step1() {
   const router = useRouter();
   const { name, strain, growthStage, setField } = usePlantForm();
   const theme = useColorScheme() ?? 'dark';
+  const insets = useSafeAreaInsets();
 
   const isValid = name.trim().length > 0;
   const [strainMenu, setStrainMenu] = React.useState(false);
@@ -38,14 +40,15 @@ export default function Step1() {
   } as const;
 
   return (
-    <KeyboardAvoidingView
-      style={{ flex: 1 }}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-    >
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-        <ScrollView
-          style={{ flex: 1, backgroundColor: Colors[theme].background }}
-          contentContainerStyle={{ padding: 24, gap: 16 }}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: Colors[theme].background, paddingTop: insets.top + 16 }}>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+          <ScrollView
+            style={{ flex: 1 }}
+            contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 24, gap: 16 }}>
           <StepIndicatorBar currentPosition={0} />
           <Text variant="titleLarge" style={{ textAlign: 'center', marginTop: 8 }}>
             🌱 Let’s start with the basics
@@ -97,15 +100,16 @@ export default function Step1() {
             ))}
           </Menu>
 
-          <RadioButton.Group
-            onValueChange={(val) => setField('growthStage', val as any)}
+          <SegmentedButtons
             value={growthStage}
-          >
-            <RadioButton.Item label="Germination" value="germination" position="leading" />
-            <RadioButton.Item label="Seedling" value="seedling" position="leading" />
-            <RadioButton.Item label="Vegetative" value="vegetative" position="leading" />
-            <RadioButton.Item label="Flowering" value="flowering" position="leading" />
-          </RadioButton.Group>
+            onValueChange={(val) => setField('growthStage', val as any)}
+            buttons={[
+              { value: 'germination', label: 'Germination' },
+              { value: 'seedling', label: 'Seedling' },
+              { value: 'vegetative', label: 'Vegetative' },
+              { value: 'flowering', label: 'Flowering' },
+            ]}
+          />
 
           <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 24 }}>
             <Button mode="outlined" onPress={() => router.back()}>
@@ -122,5 +126,6 @@ export default function Step1() {
         </ScrollView>
       </TouchableWithoutFeedback>
     </KeyboardAvoidingView>
+  </SafeAreaView>
   );
 }

--- a/WeedGrowApp/app/add-plant/step2.tsx
+++ b/WeedGrowApp/app/add-plant/step2.tsx
@@ -7,10 +7,12 @@ import {
   TouchableWithoutFeedback,
   Keyboard,
 } from 'react-native';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   TextInput,
   Button,
   Menu,
+  SegmentedButtons,
 } from 'react-native-paper';
 import { useRouter } from 'expo-router';
 
@@ -23,6 +25,7 @@ export default function Step2() {
   const router = useRouter();
   const { environment, potSize, sunlightExposure, plantedIn, setField } = usePlantForm();
   const theme = useColorScheme() ?? 'dark';
+  const insets = useSafeAreaInsets();
 
   const [potMenu, setPotMenu] = React.useState(false);
   const [sunMenu, setSunMenu] = React.useState(false);
@@ -34,27 +37,26 @@ export default function Step2() {
   } as const;
 
   return (
-    <KeyboardAvoidingView
-      style={{ flex: 1 }}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-    >
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-        <ScrollView
-          style={{ flex: 1, backgroundColor: Colors[theme].background }}
-          contentContainerStyle={{ padding: 24, gap: 16 }}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: Colors[theme].background, paddingTop: insets.top + 16 }}>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+          <ScrollView
+            style={{ flex: 1 }}
+            contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 24, gap: 16 }}>
           <StepIndicatorBar currentPosition={1} />
 
-          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
-            {['outdoor', 'greenhouse', 'indoor'].map((opt) => (
-              <Button
-                key={opt}
-                mode={environment === opt ? 'contained' : 'outlined'}
-                onPress={() => setField('environment', opt as any)}
-              >
-                {opt.charAt(0).toUpperCase() + opt.slice(1)}
-              </Button>
-            ))}
-          </View>
+          <SegmentedButtons
+            value={environment}
+            onValueChange={(val) => setField('environment', val as any)}
+            buttons={[
+              { value: 'outdoor', label: 'Outdoor' },
+              { value: 'greenhouse', label: 'Greenhouse' },
+              { value: 'indoor', label: 'Indoor' },
+            ]}
+          />
 
           <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
             {['pot', 'ground'].map((opt) => (
@@ -131,5 +133,6 @@ export default function Step2() {
         </ScrollView>
       </TouchableWithoutFeedback>
     </KeyboardAvoidingView>
+  </SafeAreaView>
   );
 }

--- a/WeedGrowApp/app/add-plant/step3.tsx
+++ b/WeedGrowApp/app/add-plant/step3.tsx
@@ -8,6 +8,7 @@ import {
   Keyboard,
   Image,
 } from 'react-native';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { TextInput, Button } from 'react-native-paper';
 import * as Location from 'expo-location';
 import { useRouter } from 'expo-router';
@@ -23,6 +24,7 @@ export default function Step3() {
   const theme = useColorScheme() ?? 'dark';
   const lat = location?.lat?.toString() ?? '';
   const lng = location?.lng?.toString() ?? '';
+  const insets = useSafeAreaInsets();
 
   const [loading, setLoading] = React.useState(false);
 
@@ -56,14 +58,15 @@ export default function Step3() {
   };
 
   return (
-    <KeyboardAvoidingView
-      style={{ flex: 1 }}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-    >
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-        <ScrollView
-          style={{ flex: 1, backgroundColor: Colors[theme].background }}
-          contentContainerStyle={{ padding: 24, gap: 16 }}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: Colors[theme].background, paddingTop: insets.top + 16 }}>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+          <ScrollView
+            style={{ flex: 1 }}
+            contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 24, gap: 16 }}>
           <StepIndicatorBar currentPosition={2} />
 
           <Button
@@ -135,5 +138,6 @@ export default function Step3() {
         </ScrollView>
       </TouchableWithoutFeedback>
     </KeyboardAvoidingView>
+  </SafeAreaView>
   );
 }

--- a/WeedGrowApp/app/add-plant/step4.tsx
+++ b/WeedGrowApp/app/add-plant/step4.tsx
@@ -8,6 +8,7 @@ import {
   Keyboard,
   StyleSheet,
 } from 'react-native';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   TextInput,
   Button,
@@ -26,6 +27,7 @@ export default function Step4() {
   const router = useRouter();
   const { wateringFrequency, fertilizer, pests, trainingTags, setField } = usePlantForm();
   const theme = useColorScheme() ?? 'dark';
+  const insets = useSafeAreaInsets();
 
   const [waterMenu, setWaterMenu] = React.useState(false);
 
@@ -43,14 +45,15 @@ export default function Step4() {
   });
 
   return (
-    <KeyboardAvoidingView
-      style={{ flex: 1 }}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-    >
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-        <ScrollView
-          style={{ flex: 1, backgroundColor: Colors[theme].background }}
-          contentContainerStyle={{ padding: 24, gap: 16 }}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: Colors[theme].background, paddingTop: insets.top + 16 }}>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+          <ScrollView
+            style={{ flex: 1 }}
+            contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 24, gap: 16 }}>
           <StepIndicatorBar currentPosition={3} />
 
           <Menu
@@ -134,5 +137,6 @@ export default function Step4() {
         </ScrollView>
       </TouchableWithoutFeedback>
     </KeyboardAvoidingView>
+  </SafeAreaView>
   );
 }

--- a/WeedGrowApp/app/add-plant/step5.tsx
+++ b/WeedGrowApp/app/add-plant/step5.tsx
@@ -8,6 +8,7 @@ import {
   Keyboard,
   Image,
 } from 'react-native';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { TextInput, Button, Snackbar } from 'react-native-paper';
 import * as ImagePicker from 'expo-image-picker';
 import { useRouter } from 'expo-router';
@@ -22,6 +23,7 @@ export default function Step5() {
   const { notes, imageUri, setField } = usePlantForm();
   const [snackVisible, setSnackVisible] = React.useState(false);
   const theme = useColorScheme() ?? 'dark';
+  const insets = useSafeAreaInsets();
 
   const inputStyle = {
     borderRadius: 8,
@@ -40,14 +42,15 @@ export default function Step5() {
   };
 
   return (
-    <KeyboardAvoidingView
-      style={{ flex: 1 }}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-    >
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-        <ScrollView
-          style={{ flex: 1, backgroundColor: Colors[theme].background }}
-          contentContainerStyle={{ padding: 24, gap: 16 }}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: Colors[theme].background, paddingTop: insets.top + 16 }}>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+          <ScrollView
+            style={{ flex: 1 }}
+            contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 24, gap: 16 }}>
           <StepIndicatorBar currentPosition={4} />
 
           <View style={{ flexDirection: 'row', gap: 8 }}>
@@ -91,5 +94,6 @@ export default function Step5() {
         </ScrollView>
       </TouchableWithoutFeedback>
     </KeyboardAvoidingView>
+  </SafeAreaView>
   );
 }

--- a/WeedGrowApp/components/StepIndicatorBar.tsx
+++ b/WeedGrowApp/components/StepIndicatorBar.tsx
@@ -1,14 +1,12 @@
 import StepIndicator from 'react-native-step-indicator';
 import React from 'react';
 import { View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
 const labels = ['Basic Info', 'Environment', 'Location', 'Care', 'Photo'];
 
 export default function StepIndicatorBar({ currentPosition }: { currentPosition: number }) {
-  const insets = useSafeAreaInsets();
   const theme = useColorScheme() ?? 'dark';
 
   const customStyles = {
@@ -36,7 +34,7 @@ export default function StepIndicatorBar({ currentPosition }: { currentPosition:
   } as const;
 
   return (
-    <View style={{ marginTop: insets.top + 8, marginBottom: 16 }}>
+    <View style={{ marginBottom: 16 }}>
       <StepIndicator
         customStyles={customStyles}
         currentPosition={currentPosition}


### PR DESCRIPTION
## Summary
- use safe-area-context in root layout
- adjust StepIndicatorBar spacing
- wrap Add Plant screens in SafeAreaView
- replace radio buttons with SegmentedButtons
- group environment choices with SegmentedButtons
- apply consistent padding across screens

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841fd9d69148330af2b5cf380cf84fe