### PR TITLE
Switch to react-native-maps for plant location

### DIFF
--- a/WeedGrowApp/app/add-plant/step3.tsx
+++ b/WeedGrowApp/app/add-plant/step3.tsx
@@ -6,8 +6,8 @@ import {
   View,
   TouchableWithoutFeedback,
   Keyboard,
-  Image,
 } from 'react-native';
+import MapView, { Marker } from 'react-native-maps';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { TextInput, Button } from 'react-native-paper';
 import * as Location from 'expo-location';
@@ -119,12 +119,20 @@ export default function Step3() {
           />
 
           {location && (
-            <Image
-              source={{
-                uri: `https://maps.googleapis.com/maps/api/staticmap?center=${lat},${lng}&zoom=15&size=600x300&markers=color:green|${lat},${lng}`,
-              }}
+            <MapView
               style={{ height: 150, borderRadius: 8 }}
-            />
+              region={{
+                latitude: location.lat,
+                longitude: location.lng,
+                latitudeDelta: 0.005,
+                longitudeDelta: 0.005,
+              }}
+            >
+              <Marker
+                coordinate={{ latitude: location.lat, longitude: location.lng }}
+                pinColor="green"
+              />
+            </MapView>
           )}
 
           <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 24 }}>

--- a/WeedGrowApp/package.json
+++ b/WeedGrowApp/package.json
@@ -38,6 +38,7 @@
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
+    "react-native-maps": "^1.5.0",
     "zustand": "^4.5.2",
     "react-native-step-indicator": "^1.0.3"
   },


### PR DESCRIPTION
## Summary
- swap Google static map for `react-native-maps`
- add `react-native-maps` dependency

## Testing
- `npm run lint` (fails: `expo: not found`)
- `npm run lint` in `weed-grow-web` (fails: cannot find `@eslint/js`)

------
https://chatgpt.com/codex/tasks/task_e_684223e2fb94833084208c2853de1913