### PR TITLE
Refactor repeated input styles

### DIFF
--- a/WeedGrowApp/app/add-plant/step1.tsx
+++ b/WeedGrowApp/app/add-plant/step1.tsx
@@ -21,6 +21,7 @@ import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { formInputStyle } from '@/constants/FormInputStyle';
 
 export default function Step1() {
   const router = useRouter();
@@ -33,11 +34,6 @@ export default function Step1() {
   const [strainSearch, setStrainSearch] = React.useState('');
   const strains = ['Sativa', 'Indica', 'Hybrid'];
 
-  const inputStyle = {
-    borderRadius: 8,
-    padding: 12,
-    fontSize: 16,
-  } as const;
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: Colors[theme].background, paddingTop: 8 }}>
@@ -58,7 +54,7 @@ export default function Step1() {
             label="Plant Name"
             value={name}
             onChangeText={(text) => setField('name', text)}
-            style={inputStyle}
+            style={formInputStyle}
           />
 
           <Menu
@@ -69,7 +65,7 @@ export default function Step1() {
                 label="Strain"
                 value={strain || 'Unknown'}
                 editable={false}
-                style={inputStyle}
+                style={formInputStyle}
                 right={
                   <TextInput.Icon
                     icon="menu-down"

--- a/WeedGrowApp/app/add-plant/step2.tsx
+++ b/WeedGrowApp/app/add-plant/step2.tsx
@@ -20,6 +20,7 @@ import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { formInputStyle } from '@/constants/FormInputStyle';
 
 export default function Step2() {
   const router = useRouter();
@@ -30,11 +31,6 @@ export default function Step2() {
   const [potMenu, setPotMenu] = React.useState(false);
   const [sunMenu, setSunMenu] = React.useState(false);
 
-  const inputStyle = {
-    borderRadius: 8,
-    padding: 12,
-    fontSize: 16,
-  } as const;
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: Colors[theme].background, paddingTop: 8 }}>
@@ -78,7 +74,7 @@ export default function Step2() {
                 <TextInput
                   label="Pot Size"
                   value={potSize}
-                  style={inputStyle}
+                  style={formInputStyle}
                   editable={false}
                   right={<TextInput.Icon icon="menu-down" onPress={() => setPotMenu(true)} />}
                 />
@@ -104,7 +100,7 @@ export default function Step2() {
               <TextInput
                 label="Sunlight Exposure"
                 value={sunlightExposure}
-                style={inputStyle}
+                style={formInputStyle}
                 editable={false}
                 right={<TextInput.Icon icon="menu-down" onPress={() => setSunMenu(true)} />}
               />

--- a/WeedGrowApp/app/add-plant/step3.tsx
+++ b/WeedGrowApp/app/add-plant/step3.tsx
@@ -20,6 +20,7 @@ import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { formInputStyle } from '@/constants/FormInputStyle';
 
 const screen = Dimensions.get('window');
 
@@ -34,11 +35,6 @@ export default function Step3() {
   const [loading, setLoading] = React.useState(false);
   const mapRef = React.useRef<MapView | null>(null);
 
-  const inputStyle = {
-    borderRadius: 8,
-    padding: 12,
-    fontSize: 16,
-  } as const;
 
   const getLocation = async () => {
     try {
@@ -128,7 +124,7 @@ export default function Step3() {
               label="Location Nickname"
               value={locationNickname}
               onChangeText={(text) => setField('locationNickname', text)}
-              style={inputStyle}
+              style={formInputStyle}
             />
 
             <View style={{ height: 300, borderRadius: 12, overflow: 'hidden' }}>

--- a/WeedGrowApp/app/add-plant/step4.tsx
+++ b/WeedGrowApp/app/add-plant/step4.tsx
@@ -22,6 +22,7 @@ import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { formInputStyle } from '@/constants/FormInputStyle';
 
 export default function Step4() {
   const router = useRouter();
@@ -34,11 +35,6 @@ export default function Step4() {
   const pestOptions = ['Spider Mites', 'Powdery Mildew', 'Aphids'];
   const trainingOptions = ['LST', 'Topping', 'SCROG'];
 
-  const inputStyle = {
-    borderRadius: 8,
-    padding: 12,
-    fontSize: 16,
-  } as const;
 
   const styles = StyleSheet.create({
     sectionTitle: { fontWeight: 'bold', marginTop: 16, marginBottom: 8, fontSize: 16 },
@@ -63,7 +59,7 @@ export default function Step4() {
               <TextInput
                 label="Watering Frequency"
                 value={wateringFrequency}
-                style={inputStyle}
+                style={formInputStyle}
                 editable={false}
                 right={<TextInput.Icon icon="menu-down" onPress={() => setWaterMenu(true)} />}
               />
@@ -85,7 +81,7 @@ export default function Step4() {
             label="Fertilizer"
             value={fertilizer}
             onChangeText={(text) => setField('fertilizer', text)}
-            style={inputStyle}
+            style={formInputStyle}
           />
 
           <Text style={styles.sectionTitle}>Pest History</Text>

--- a/WeedGrowApp/app/add-plant/step5.tsx
+++ b/WeedGrowApp/app/add-plant/step5.tsx
@@ -17,6 +17,7 @@ import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { formInputStyle } from '@/constants/FormInputStyle';
 
 export default function Step5() {
   const router = useRouter();
@@ -25,11 +26,6 @@ export default function Step5() {
   const theme = useColorScheme() ?? 'dark';
   const insets = useSafeAreaInsets();
 
-  const inputStyle = {
-    borderRadius: 8,
-    padding: 12,
-    fontSize: 16,
-  } as const;
 
   const pickImage = async (fromCamera: boolean) => {
     const result = fromCamera
@@ -76,7 +72,7 @@ export default function Step5() {
             onChangeText={(text) => setField('notes', text)}
             multiline
             placeholder="Add any observations here..."
-            style={[inputStyle, { height: 120 }]}
+            style={[formInputStyle, { height: 120 }]}
           />
 
           <Snackbar visible={snackVisible} onDismiss={() => setSnackVisible(false)}>

--- a/WeedGrowApp/constants/FormInputStyle.ts
+++ b/WeedGrowApp/constants/FormInputStyle.ts
@@ -1,0 +1,5 @@
+export const formInputStyle = {
+  borderRadius: 8,
+  padding: 12,
+  fontSize: 16,
+} as const;


### PR DESCRIPTION
## Summary
- centralize shared form input style
- reuse it across `add-plant` steps

## Testing
- `npm run lint` in `WeedGrowApp` *(fails: expo not found)*
- `npm run lint` in `weed-grow-web` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6842f430cbcc8330aff899d31e8a6ec2