### PR TITLE
Implement plant fetch in UnknownScreen

### DIFF
--- a/WeedGrowApp/app/(tabs)/unknown.tsx
+++ b/WeedGrowApp/app/(tabs)/unknown.tsx
@@ -1,85 +1,73 @@
-// File: app/(tabs)/unknown.tsx
+import React, { useEffect, useState } from 'react';
+import { StyleSheet, FlatList } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+import { collection, getDocs, query, where } from 'firebase/firestore';
+import { db } from '../../services/firebase';
+import { Plant } from '@/firestoreModels';
+import { ActivityIndicator } from 'react-native-paper';
 
-import React, { useEffect, useState } from "react";
-import { StyleSheet, FlatList } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
-import { ThemedView } from "@/components/ThemedView";
-import { ThemedText } from "@/components/ThemedText";
-
-import { collection, getDocs } from "firebase/firestore";
-import { db } from "../../services/firebase";
-
-interface TestDoc {
+interface PlantItem extends Plant {
   id: string;
-  Plant: string;
-  Status: string;
 }
 
 export default function UnknownScreen() {
-  const [docs, setDocs] = useState<TestDoc[]>([]);
+  const [plants, setPlants] = useState<PlantItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const fetchTestDocs = async () => {
+    const fetchPlants = async () => {
       try {
-        const testCol = collection(db, "test");
-        const snapshot = await getDocs(testCol);
-        const items: TestDoc[] = snapshot.docs.map((docSnap) => {
-          const data = docSnap.data() as any;
-          return {
-            id: docSnap.id,
-            Plant: data.Plant,
-            Status: data.Status,
-          };
-        });
-        setDocs(items);
+        const userId = 'testUser123';
+        const plantsQuery = query(
+          collection(db, 'plants'),
+          where('owners', 'array-contains', userId)
+        );
+        const snapshot = await getDocs(plantsQuery);
+        const items: PlantItem[] = snapshot.docs.map((doc) => ({
+          id: doc.id,
+          ...(doc.data() as Plant),
+        }));
+        setPlants(items);
       } catch (e: any) {
-        console.error("Error fetching test docs:", e);
-        setError(e.message || "Unknown error");
+        console.error('Error fetching plants:', e);
+        setError(e.message || 'Unknown error');
       } finally {
         setLoading(false);
       }
     };
 
-    fetchTestDocs();
+    fetchPlants();
   }, []);
 
   return (
-    // 1) Wrap in SafeAreaView so header isn't under the status bar
     <SafeAreaView style={styles.safeArea}>
       <ThemedView style={styles.container}>
         <ThemedText type="title" style={styles.title}>
-          Firestore Test
+          My Plants
         </ThemedText>
-
-        {loading && <ThemedText>Loading data…</ThemedText>}
-
+        {loading && <ActivityIndicator style={styles.loading} />}
         {error && (
           <ThemedText type="error" style={styles.errorText}>
             ❌ Error: {error}
           </ThemedText>
         )}
-
-        {!loading && !error && docs.length === 0 && (
-          <ThemedText>No test documents found.</ThemedText>
+        {!loading && !error && plants.length === 0 && (
+          <ThemedText>No plants found.</ThemedText>
         )}
-
-        {!loading && !error && docs.length > 0 && (
+        {!loading && !error && plants.length > 0 && (
           <FlatList
-            data={docs}
+            data={plants}
             keyExtractor={(item) => item.id}
             renderItem={({ item }) => (
-              <ThemedView style={styles.cardDark} key={item.id}>
-                <ThemedText>
-                  <ThemedText type="bold">ID:</ThemedText> {item.id}
-                </ThemedText>
-                <ThemedText>
-                  <ThemedText type="bold">Plant:</ThemedText> {item.Plant}
-                </ThemedText>
-                <ThemedText>
-                  <ThemedText type="bold">Status:</ThemedText> {item.Status}
-                </ThemedText>
+              <ThemedView style={styles.card} key={item.id}>
+                <ThemedText type="subtitle">{item.name}</ThemedText>
+                <ThemedText>Strain: {item.strain}</ThemedText>
+                <ThemedText>Stage: {item.growthStage}</ThemedText>
+                <ThemedText>Status: {item.status}</ThemedText>
+                <ThemedText>Environment: {item.environment}</ThemedText>
               </ThemedView>
             )}
           />
@@ -92,24 +80,27 @@ export default function UnknownScreen() {
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: "#000", // match dark background so it doesn’t flash white
+    backgroundColor: '#000',
   },
   container: {
     flex: 1,
     padding: 16,
   },
   title: {
-    textAlign: "center",
+    textAlign: 'center',
     marginBottom: 20,
   },
+  loading: {
+    marginTop: 20,
+  },
   errorText: {
-    color: "red",
+    color: 'red',
     marginTop: 10,
   },
-  cardDark: {
+  card: {
     marginBottom: 16,
     padding: 12,
-    backgroundColor: "#333", // dark gray so the default white text is visible
+    backgroundColor: '#333',
     borderRadius: 8,
   },
 });


### PR DESCRIPTION
## Summary
- pull a user's plants from Firestore
- show plant details in a card layout

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431bba80a08330a8f0d587624b67d2