### PR TITLE
Enable list of plants in Unknown screen

### DIFF
--- a/WeedGrowApp/app/(tabs)/unknown.tsx
+++ b/WeedGrowApp/app/(tabs)/unknown.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, FlatList } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
+import { PlantCard } from '@/components/PlantCard';
 import { collection, getDocs, query, where } from 'firebase/firestore';
 import { db } from '../../services/firebase';
 import { Plant } from '@/firestoreModels';
@@ -61,15 +62,7 @@ export default function UnknownScreen() {
           <FlatList
             data={plants}
             keyExtractor={(item) => item.id}
-            renderItem={({ item }) => (
-              <ThemedView style={styles.card} key={item.id}>
-                <ThemedText type="subtitle">{item.name}</ThemedText>
-                <ThemedText>Strain: {item.strain}</ThemedText>
-                <ThemedText>Stage: {item.growthStage}</ThemedText>
-                <ThemedText>Status: {item.status}</ThemedText>
-                <ThemedText>Environment: {item.environment}</ThemedText>
-              </ThemedView>
-            )}
+            renderItem={({ item }) => <PlantCard plant={item} />}
           />
         )}
       </ThemedView>
@@ -96,11 +89,5 @@ const styles = StyleSheet.create({
   errorText: {
     color: 'red',
     marginTop: 10,
-  },
-  card: {
-    marginBottom: 16,
-    padding: 12,
-    backgroundColor: '#333',
-    borderRadius: 8,
   },
 });

--- a/WeedGrowApp/components/PlantCard.tsx
+++ b/WeedGrowApp/components/PlantCard.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+import { Plant } from '@/firestoreModels';
+
+export interface PlantCardProps {
+  plant: Plant;
+}
+
+export function PlantCard({ plant }: PlantCardProps) {
+  return (
+    <ThemedView style={styles.card}>
+      <ThemedText type="subtitle">{plant.name}</ThemedText>
+      <ThemedText>Strain: {plant.strain}</ThemedText>
+      <ThemedText>Stage: {plant.growthStage}</ThemedText>
+      <ThemedText>Status: {plant.status}</ThemedText>
+      <ThemedText>Environment: {plant.environment}</ThemedText>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: 16,
+    padding: 12,
+    backgroundColor: '#333',
+    borderRadius: 8,
+  },
+});
+


### PR DESCRIPTION
## Summary
- add a `PlantCard` component for displaying plant info
- render a `FlatList` of `PlantCard` items on the Unknown screen

## Testing
- `npm run lint` *(fails: `expo` not found)*
- `npm run lint` in `weed-grow-web` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_68431e37e19c8330a1d00c4a8055ff26