### PR TITLE
Show all plants in listing

### DIFF
--- a/WeedGrowApp/app/(tabs)/unknown.tsx
+++ b/WeedGrowApp/app/(tabs)/unknown.tsx
@@ -21,11 +21,8 @@ export default function UnknownScreen() {
   useEffect(() => {
     const fetchPlants = async () => {
       try {
-        const userId = 'testUser123';
-        const plantsQuery = query(
-          collection(db, 'plants'),
-          where('owners', 'array-contains', userId)
-        );
+        const plantsQuery = query(collection(db, 'plants'));
+        // In the future, we'll display only the current user's plants here.
         const snapshot = await getDocs(plantsQuery);
         const items: PlantItem[] = snapshot.docs.map((doc) => ({
           id: doc.id,


### PR DESCRIPTION
## Summary
- show every plant in the tab screen
- note that user filtering will return later

## Testing
- `npm run lint` in `WeedGrowApp` *(fails: expo not found)*
- `npm run lint` in `weed-grow-web` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68431fd3f9e48330a86e0b6f5ffb6092