### PR TITLE
Add Firestore save for new plants

### DIFF
--- a/WeedGrowApp/app/add-plant/review.tsx
+++ b/WeedGrowApp/app/add-plant/review.tsx
@@ -8,6 +8,8 @@ import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
+import { db } from '@/services/firebase';
 
 export default function Review() {
   const router = useRouter();
@@ -15,10 +17,34 @@ export default function Review() {
   const theme = useColorScheme() ?? 'dark';
   const insets = useSafeAreaInsets();
 
-  const save = () => {
-    console.log('Plant saved:', { ...form });
-    form.reset();
-    router.replace('/plants');
+  const save = async () => {
+    try {
+      await addDoc(collection(db, 'plants'), {
+        name: form.name,
+        strain: form.strain,
+        owners: ['demoUser'],
+        growthStage: form.growthStage,
+        status: 'active',
+        environment: form.environment,
+        plantedIn: form.plantedIn,
+        potSize: form.potSize ?? null,
+        sunlightExposure: form.sunlightExposure ?? null,
+        wateringFrequency: form.wateringFrequency ?? null,
+        fertilizer: form.fertilizer ?? null,
+        pests: form.pests ?? null,
+        trainingTags: form.trainingTags ?? null,
+        notes: form.notes ?? null,
+        imageUri: form.imageUri ?? null,
+        location: form.location ?? null,
+        locationNickname: form.locationNickname ?? null,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      });
+      form.reset();
+      router.replace('/unknown');
+    } catch (e) {
+      console.error('Error saving plant:', e);
+    }
   };
 
   const styles = StyleSheet.create({


### PR DESCRIPTION
## Summary
- save plant data to Firestore in add plant review step

## Testing
- `npm run lint` in WeedGrowApp *(fails: `expo` not found)*
- `npm run lint` in weed-grow-web *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_684320d170dc83309861bd5c89f34381