### PR TITLE
Implement plant detail view with shared element transition

### DIFF
--- a/WeedGrowApp/app/plant/[id].tsx
+++ b/WeedGrowApp/app/plant/[id].tsx
@@ -16,7 +16,10 @@ export default function PlantDetailScreen() {
 
   useEffect(() => {
     const fetchPlant = async () => {
-      if (!id) return;
+      if (!id) {
+        setLoading(false);
+        return;
+      }
       const ref = doc(db, 'plants', String(id));
       const snap = await getDoc(ref);
       if (snap.exists()) {

--- a/WeedGrowApp/app/plant/[id].tsx
+++ b/WeedGrowApp/app/plant/[id].tsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useState } from 'react';
+import { View, StyleSheet, ScrollView, Image, ActivityIndicator } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+import { SharedElement } from 'react-navigation-shared-element';
+import { doc, getDoc } from 'firebase/firestore';
+import { Plant } from '@/firestoreModels';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+import { db } from '../../services/firebase';
+import { List } from 'react-native-paper';
+
+export default function PlantDetailScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const [plant, setPlant] = useState<Plant | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchPlant = async () => {
+      if (!id) return;
+      const ref = doc(db, 'plants', String(id));
+      const snap = await getDoc(ref);
+      if (snap.exists()) {
+        setPlant(snap.data() as Plant);
+      }
+      setLoading(false);
+    };
+    fetchPlant();
+  }, [id]);
+
+  if (loading) {
+    return (
+      <ThemedView style={styles.center}>
+        <ActivityIndicator />
+      </ThemedView>
+    );
+  }
+
+  if (!plant) {
+    return (
+      <ThemedView style={styles.center}>
+        <ThemedText>Plant not found.</ThemedText>
+      </ThemedView>
+    );
+  }
+
+  return (
+    <ScrollView contentContainerStyle={{ padding: 16 }}>
+      {plant.imageUri && (
+        <SharedElement id={`plant.${id}.photo`} style={styles.imageWrapper}>
+          <Image source={{ uri: plant.imageUri }} style={styles.image} />
+        </SharedElement>
+      )}
+      <ThemedText type="title" style={styles.title}>{plant.name}</ThemedText>
+      <ThemedText style={styles.strain}>{plant.strain}</ThemedText>
+
+      <View style={styles.section}>
+        <List.Item
+          title="Growth Stage"
+          description={plant.growthStage}
+          left={props => <List.Icon {...props} icon="sprout" />}
+        />
+        <List.Item
+          title="Environment"
+          description={plant.environment}
+          left={props => <List.Icon {...props} icon={plant.environment === 'indoor' ? 'home' : plant.environment === 'greenhouse' ? 'greenhouse' : 'tree'} />}
+        />
+        <List.Item
+          title="Status"
+          description={plant.status}
+          left={props => <List.Icon {...props} icon={plant.status === 'active' ? 'check-circle-outline' : plant.status === 'archived' ? 'archive' : plant.status === 'harvested' ? 'flower' : 'skull'} />}
+        />
+      </View>
+
+      {plant.notes ? (
+        <View style={styles.section}>
+          <ThemedText type="subtitle">Notes</ThemedText>
+          <ThemedText>{plant.notes}</ThemedText>
+        </View>
+      ) : null}
+
+      {plant.fertilizer ? (
+        <View style={styles.section}>
+          <ThemedText type="subtitle">Fertilization</ThemedText>
+          <ThemedText>{plant.fertilizer}</ThemedText>
+        </View>
+      ) : null}
+
+      {plant.pests && plant.pests.length > 0 ? (
+        <View style={styles.section}>
+          <ThemedText type="subtitle">Pests</ThemedText>
+          <ThemedText>{plant.pests.join(', ')}</ThemedText>
+        </View>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+PlantDetailScreen.sharedElements = (route: any) => {
+  const { id } = route.params;
+  return [`plant.${id}.photo`];
+};
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    marginTop: 12,
+    marginBottom: 4,
+    textAlign: 'center',
+  },
+  strain: {
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  imageWrapper: {
+    alignSelf: 'center',
+    borderRadius: 8,
+    overflow: 'hidden',
+  },
+  image: {
+    height: 200,
+    width: 200,
+    borderRadius: 8,
+  },
+  section: {
+    marginTop: 16,
+    gap: 4,
+  },
+});

--- a/WeedGrowApp/app/plant/_layout.tsx
+++ b/WeedGrowApp/app/plant/_layout.tsx
@@ -1,0 +1,10 @@
+import { withLayoutContext } from 'expo-router';
+import { createSharedElementStackNavigator } from 'react-navigation-shared-element';
+import React from 'react';
+
+const Stack = createSharedElementStackNavigator();
+const PlantStack = withLayoutContext(Stack.Navigator);
+
+export default function PlantLayout() {
+  return <PlantStack screenOptions={{ headerShown: false }} />;
+}

--- a/WeedGrowApp/components/PlantCard.tsx
+++ b/WeedGrowApp/components/PlantCard.tsx
@@ -1,23 +1,36 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, TouchableOpacity, Image } from 'react-native';
+import { SharedElement } from 'react-navigation-shared-element';
+import { useRouter } from 'expo-router';
 
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
+import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { Plant } from '@/firestoreModels';
 
 export interface PlantCardProps {
-  plant: Plant;
+  plant: Plant & { id: string };
 }
 
 export function PlantCard({ plant }: PlantCardProps) {
+  const router = useRouter();
   return (
-    <ThemedView style={styles.card}>
-      <ThemedText type="subtitle">{plant.name}</ThemedText>
-      <ThemedText>Strain: {plant.strain}</ThemedText>
-      <ThemedText>Stage: {plant.growthStage}</ThemedText>
-      <ThemedText>Status: {plant.status}</ThemedText>
-      <ThemedText>Environment: {plant.environment}</ThemedText>
-    </ThemedView>
+    <TouchableOpacity
+      onPress={() => router.push({ pathname: '/plant/[id]', params: { id: plant.id } })}
+    >
+      <ThemedView style={styles.card}>
+        {plant.imageUri && (
+          <SharedElement id={`plant.${plant.id}.photo`} style={styles.imageWrap}>
+            <Image source={{ uri: plant.imageUri }} style={styles.image} />
+          </SharedElement>
+        )}
+        <ThemedText type="subtitle">{plant.name}</ThemedText>
+        <ThemedText>Strain: {plant.strain}</ThemedText>
+        <ThemedText><MaterialCommunityIcons name="sprout" size={16} color="#aaa" /> {plant.growthStage}</ThemedText>
+        <ThemedText><MaterialCommunityIcons name={plant.status === "active" ? "check-circle-outline" : plant.status === "archived" ? "archive" : plant.status === "harvested" ? "flower" : "skull"} size={16} color="#aaa" /> {plant.status}</ThemedText>
+        <ThemedText><MaterialCommunityIcons name={plant.environment === "indoor" ? "home" : plant.environment === "greenhouse" ? "greenhouse" : "tree"} size={16} color="#aaa" /> {plant.environment}</ThemedText>
+      </ThemedView>
+    </TouchableOpacity>
   );
 }
 
@@ -28,5 +41,15 @@ const styles = StyleSheet.create({
     backgroundColor: '#333',
     borderRadius: 8,
   },
+  imageWrap: {
+    marginBottom: 8,
+    borderRadius: 8,
+    overflow: 'hidden',
+    alignSelf: 'center',
+  },
+  image: {
+    height: 100,
+    width: 100,
+    borderRadius: 8,
+  },
 });
-

--- a/WeedGrowApp/package.json
+++ b/WeedGrowApp/package.json
@@ -50,7 +50,8 @@
     "react-native-vector-icons": "^10.2.0",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
-    "zustand": "^4.5.7"
+    "zustand": "^4.5.7",
+    "react-navigation-shared-element": "^3.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- add `react-navigation-shared-element` dependency
- make `PlantCard` tappable and display icons for stage, status and environment
- create dynamic `[id]` plant detail screen
- add shared element stack for plant screens

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432a6baf2883309667ce3f438179cf