### PR TITLE
Fix deprecated expo-image-picker option

### DIFF
--- a/WeedGrowApp/app/add-plant/step5.tsx
+++ b/WeedGrowApp/app/add-plant/step5.tsx
@@ -33,8 +33,8 @@ export default function Step5() {
 
   const pickImage = async (fromCamera: boolean) => {
     const result = fromCamera
-      ? await ImagePicker.launchCameraAsync({ mediaTypes: ImagePicker.MediaTypeOptions.Images })
-      : await ImagePicker.launchImageLibraryAsync({ mediaTypes: ImagePicker.MediaTypeOptions.Images });
+      ? await ImagePicker.launchCameraAsync({ mediaTypes: ImagePicker.MediaType.Images })
+      : await ImagePicker.launchImageLibraryAsync({ mediaTypes: ImagePicker.MediaType.Images });
     if (!result.canceled) {
       setField('imageUri', result.assets[0].uri);
       setSnackVisible(true);


### PR DESCRIPTION
## Summary
- use `ImagePicker.MediaType.Images` instead of deprecated `MediaTypeOptions`

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432aef329c83309456e974e9ae5ba5