### PR TITLE
Switch to reanimated shared transitions

### DIFF
--- a/WeedGrowApp/app/plant/[id].tsx
+++ b/WeedGrowApp/app/plant/[id].tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, StyleSheet, ScrollView, Image, ActivityIndicator } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
-import { SharedElement } from 'react-navigation-shared-element';
+import Animated from 'react-native-reanimated';
 import { doc, getDoc } from 'firebase/firestore';
 import { Plant } from '@/firestoreModels';
 import { ThemedView } from '@/components/ThemedView';
@@ -49,9 +49,9 @@ export default function PlantDetailScreen() {
   return (
     <ScrollView contentContainerStyle={{ padding: 16 }}>
       {plant.imageUri && (
-        <SharedElement id={`plant.${id}.photo`} style={styles.imageWrapper}>
+        <Animated.View sharedTransitionTag={`plant.${id}.photo`} style={styles.imageWrapper}>
           <Image source={{ uri: plant.imageUri }} style={styles.image} />
-        </SharedElement>
+        </Animated.View>
       )}
       <ThemedText type="title" style={styles.title}>{plant.name}</ThemedText>
       <ThemedText style={styles.strain}>{plant.strain}</ThemedText>
@@ -98,10 +98,6 @@ export default function PlantDetailScreen() {
   );
 }
 
-PlantDetailScreen.sharedElements = (route: any) => {
-  const { id } = route.params;
-  return [`plant.${id}.photo`];
-};
 
 const styles = StyleSheet.create({
   center: {

--- a/WeedGrowApp/app/plant/_layout.tsx
+++ b/WeedGrowApp/app/plant/_layout.tsx
@@ -1,10 +1,6 @@
-import { withLayoutContext } from 'expo-router';
-import { createSharedElementStackNavigator } from 'react-navigation-shared-element';
+import { Stack } from 'expo-router';
 import React from 'react';
 
-const Stack = createSharedElementStackNavigator();
-const PlantStack = withLayoutContext(Stack.Navigator);
-
 export default function PlantLayout() {
-  return <PlantStack screenOptions={{ headerShown: false }} />;
+  return <Stack screenOptions={{ headerShown: false }} />;
 }

--- a/WeedGrowApp/components/PlantCard.tsx
+++ b/WeedGrowApp/components/PlantCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, TouchableOpacity, Image } from 'react-native';
-import { SharedElement } from 'react-navigation-shared-element';
+import Animated from 'react-native-reanimated';
 import { useRouter } from 'expo-router';
 
 import { ThemedView } from '@/components/ThemedView';
@@ -20,9 +20,12 @@ export function PlantCard({ plant }: PlantCardProps) {
     >
       <ThemedView style={styles.card}>
         {plant.imageUri && (
-          <SharedElement id={`plant.${plant.id}.photo`} style={styles.imageWrap}>
+          <Animated.View
+            sharedTransitionTag={`plant.${plant.id}.photo`}
+            style={styles.imageWrap}
+          >
             <Image source={{ uri: plant.imageUri }} style={styles.image} />
-          </SharedElement>
+          </Animated.View>
         )}
         <ThemedText type="subtitle">{plant.name}</ThemedText>
         <ThemedText>Strain: {plant.strain}</ThemedText>

--- a/WeedGrowApp/package.json
+++ b/WeedGrowApp/package.json
@@ -50,8 +50,7 @@
     "react-native-vector-icons": "^10.2.0",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
-    "zustand": "^4.5.7",
-    "react-navigation-shared-element": "^3.1.2"
+    "zustand": "^4.5.7"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- drop unused `react-navigation-shared-element`
- use `react-native-reanimated` shared element transitions

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm run lint` in `weed-grow-web` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68432d6323608330ab9f7f0224bb5880