### PR TITLE
Fix theme typings

### DIFF
--- a/WeedGrowApp/app/(tabs)/_layout.tsx
+++ b/WeedGrowApp/app/(tabs)/_layout.tsx
@@ -5,11 +5,11 @@ import { Platform } from 'react-native';
 import { HapticTab } from '@/components/HapticTab';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import TabBarBackground from '@/components/ui/TabBarBackground';
-import { Colors } from '@/constants/Colors';
+import { Colors, Theme } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
 export default function TabLayout() {
-  const colorScheme = useColorScheme();
+  const colorScheme: Theme | null = useColorScheme();
 
   return (
     <Tabs

--- a/WeedGrowApp/app/(tabs)/_layout.tsx
+++ b/WeedGrowApp/app/(tabs)/_layout.tsx
@@ -9,7 +9,7 @@ import { Colors, Theme } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
 export default function TabLayout() {
-  const colorScheme: Theme | null = useColorScheme();
+  const colorScheme: Theme = useColorScheme() ?? 'light';
 
   return (
     <Tabs

--- a/WeedGrowApp/app/add-plant/review.tsx
+++ b/WeedGrowApp/app/add-plant/review.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
-import { Colors } from '@/constants/Colors';
+import { Colors, Theme } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
 import { db } from '@/services/firebase';
@@ -14,7 +14,7 @@ import { db } from '@/services/firebase';
 export default function Review() {
   const router = useRouter();
   const form = usePlantForm();
-  const theme = useColorScheme() ?? 'dark';
+  const theme: Theme = useColorScheme() ?? 'dark';
   const insets = useSafeAreaInsets();
 
   const save = async () => {

--- a/WeedGrowApp/app/add-plant/step1.tsx
+++ b/WeedGrowApp/app/add-plant/step1.tsx
@@ -19,13 +19,13 @@ import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
-import { Colors } from '@/constants/Colors';
+import { Colors, Theme } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
 export default function Step1() {
   const router = useRouter();
   const { name, strain, growthStage, setField } = usePlantForm();
-  const theme = useColorScheme() ?? 'dark';
+  const theme: Theme = useColorScheme() ?? 'dark';
   const insets = useSafeAreaInsets();
 
   const isValid = name.trim().length > 0;

--- a/WeedGrowApp/app/add-plant/step2.tsx
+++ b/WeedGrowApp/app/add-plant/step2.tsx
@@ -18,13 +18,13 @@ import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
-import { Colors } from '@/constants/Colors';
+import { Colors, Theme } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
 export default function Step2() {
   const router = useRouter();
   const { environment, potSize, sunlightExposure, plantedIn, setField } = usePlantForm();
-  const theme = useColorScheme() ?? 'dark';
+  const theme: Theme = useColorScheme() ?? 'dark';
   const insets = useSafeAreaInsets();
 
   const [potMenu, setPotMenu] = React.useState(false);

--- a/WeedGrowApp/app/add-plant/step3.tsx
+++ b/WeedGrowApp/app/add-plant/step3.tsx
@@ -18,7 +18,7 @@ import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
-import { Colors } from '@/constants/Colors';
+import { Colors, Theme } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
 const screen = Dimensions.get('window');
@@ -26,7 +26,7 @@ const screen = Dimensions.get('window');
 export default function Step3() {
   const router = useRouter();
   const { location, locationNickname, setField } = usePlantForm();
-  const theme = useColorScheme() ?? 'dark';
+  const theme: Theme = useColorScheme() ?? 'dark';
   const lat = location?.lat?.toString() ?? '';
   const lng = location?.lng?.toString() ?? '';
   const insets = useSafeAreaInsets();

--- a/WeedGrowApp/app/add-plant/step4.tsx
+++ b/WeedGrowApp/app/add-plant/step4.tsx
@@ -20,13 +20,13 @@ import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
-import { Colors } from '@/constants/Colors';
+import { Colors, Theme } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
 export default function Step4() {
   const router = useRouter();
   const { wateringFrequency, fertilizer, pests, trainingTags, setField } = usePlantForm();
-  const theme = useColorScheme() ?? 'dark';
+  const theme: Theme = useColorScheme() ?? 'dark';
   const insets = useSafeAreaInsets();
 
   const [waterMenu, setWaterMenu] = React.useState(false);

--- a/WeedGrowApp/app/add-plant/step5.tsx
+++ b/WeedGrowApp/app/add-plant/step5.tsx
@@ -15,14 +15,14 @@ import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
-import { Colors } from '@/constants/Colors';
+import { Colors, Theme } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
 export default function Step5() {
   const router = useRouter();
   const { notes, imageUri, setField } = usePlantForm();
   const [snackVisible, setSnackVisible] = React.useState(false);
-  const theme = useColorScheme() ?? 'dark';
+  const theme: Theme = useColorScheme() ?? 'dark';
   const insets = useSafeAreaInsets();
 
   const inputStyle = {

--- a/WeedGrowApp/components/Collapsible.tsx
+++ b/WeedGrowApp/components/Collapsible.tsx
@@ -4,12 +4,12 @@ import { StyleSheet, TouchableOpacity } from 'react-native';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { IconSymbol } from '@/components/ui/IconSymbol';
-import { Colors } from '@/constants/Colors';
+import { Colors, Theme } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
 export function Collapsible({ children, title }: PropsWithChildren & { title: string }) {
   const [isOpen, setIsOpen] = useState(false);
-  const theme = useColorScheme() ?? 'light';
+  const theme: Theme = useColorScheme() ?? 'light';
 
   return (
     <ThemedView>

--- a/WeedGrowApp/components/StepIndicatorBar.tsx
+++ b/WeedGrowApp/components/StepIndicatorBar.tsx
@@ -1,13 +1,13 @@
 import StepIndicator from 'react-native-step-indicator';
 import React from 'react';
 import { View } from 'react-native';
-import { Colors } from '@/constants/Colors';
+import { Colors, Theme } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
 const labels = ['Basic Info', 'Environment', 'Location', 'Care', 'Photo'];
 
 export default function StepIndicatorBar({ currentPosition }: { currentPosition: number }) {
-  const theme = useColorScheme() ?? 'dark';
+  const theme: Theme = useColorScheme() ?? 'dark';
 
   const customStyles = {
     stepIndicatorSize: 25,

--- a/WeedGrowApp/constants/Colors.ts
+++ b/WeedGrowApp/constants/Colors.ts
@@ -33,3 +33,5 @@ export const Colors = {
     white: whiteColor,
   },
 };
+
+export type Theme = keyof typeof Colors;

--- a/WeedGrowApp/hooks/useThemeColor.ts
+++ b/WeedGrowApp/hooks/useThemeColor.ts
@@ -3,14 +3,14 @@
  * https://docs.expo.dev/guides/color-schemes/
  */
 
-import { Colors } from '@/constants/Colors';
+import { Colors, Theme } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
 export function useThemeColor(
   props: { light?: string; dark?: string },
   colorName: keyof typeof Colors.light & keyof typeof Colors.dark
 ) {
-  const theme = useColorScheme() ?? 'light';
+  const theme: Theme = useColorScheme() ?? 'light';
   const colorFromProps = props[theme];
 
   if (colorFromProps) {


### PR DESCRIPTION
## Summary
- export `Theme` type from Colors
- use `Theme` when reading from the color map

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843334764f08330b5012734cf127510