### PR TITLE
Apply theme colors to new plant screen

### DIFF
--- a/WeedGrowApp/app/(tabs)/unknown.tsx
+++ b/WeedGrowApp/app/(tabs)/unknown.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { StyleSheet, FlatList } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { Colors } from '@/constants/Colors';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
 import { PlantCard } from '@/components/PlantCard';
@@ -17,6 +19,8 @@ export default function UnknownScreen() {
   const [plants, setPlants] = useState<PlantItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  type Theme = keyof typeof Colors;
+  const theme = (useColorScheme() ?? 'dark') as Theme;
 
   useEffect(() => {
     const fetchPlants = async () => {
@@ -41,14 +45,19 @@ export default function UnknownScreen() {
   }, []);
 
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <SafeAreaView style={[styles.safeArea, { backgroundColor: Colors[theme].background }]}>
       <ThemedView style={styles.container}>
         <ThemedText type="title" style={styles.title}>
           My Plants
         </ThemedText>
-        {loading && <ActivityIndicator style={styles.loading} />}
+        {loading && (
+          <ActivityIndicator
+            style={styles.loading}
+            color={Colors[theme].tint}
+          />
+        )}
         {error && (
-          <ThemedText type="error" style={styles.errorText}>
+          <ThemedText type="error" style={[styles.errorText, { color: Colors[theme].tint }] }>
             ❌ Error: {error}
           </ThemedText>
         )}
@@ -70,7 +79,6 @@ export default function UnknownScreen() {
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: '#000',
   },
   container: {
     flex: 1,
@@ -84,7 +92,6 @@ const styles = StyleSheet.create({
     marginTop: 20,
   },
   errorText: {
-    color: 'red',
     marginTop: 10,
   },
 });

--- a/WeedGrowApp/app/add-plant/review.tsx
+++ b/WeedGrowApp/app/add-plant/review.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ScrollView, View, Image, StyleSheet } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Button, Card, Text, Divider } from 'react-native-paper';
+import { ThemedText } from '@/components/ThemedText';
 import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
@@ -63,7 +64,7 @@ export default function Review() {
         <Card.Title title="Review Plant" />
         <Card.Content>
           <View style={{ gap: 8 }}>
-            <Text style={styles.sectionTitle}>Growth Info</Text>
+            <ThemedText style={styles.sectionTitle}>Growth Info</ThemedText>
             <View>
               <Text variant="labelLarge">Name</Text>
               <Text>{form.name}</Text>
@@ -80,7 +81,7 @@ export default function Review() {
             </View>
 
             <Divider />
-            <Text style={styles.sectionTitle}>Environment</Text>
+            <ThemedText style={styles.sectionTitle}>Environment</ThemedText>
             <View>
               <Text variant="labelLarge">Environment</Text>
               <Text>{form.environment}</Text>
@@ -134,7 +135,7 @@ export default function Review() {
             )}
 
             <Divider />
-            <Text style={styles.sectionTitle}>Care</Text>
+            <ThemedText style={styles.sectionTitle}>Care</ThemedText>
             {form.wateringFrequency && (
               <>
                 <View>

--- a/WeedGrowApp/app/add-plant/step1.tsx
+++ b/WeedGrowApp/app/add-plant/step1.tsx
@@ -15,6 +15,7 @@ import {
   Menu,
   SegmentedButtons,
 } from 'react-native-paper';
+import { ThemedText } from '@/components/ThemedText';
 import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
@@ -50,9 +51,9 @@ export default function Step1() {
             style={{ flex: 1 }}
             contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 16, gap: 16 }}>
           <StepIndicatorBar currentPosition={0} />
-          <Text variant="titleLarge" style={{ textAlign: 'center', marginTop: 8 }}>
+          <ThemedText type="title" style={{ textAlign: 'center', marginTop: 8 }}>
             🌱 Let’s start with the basics
-          </Text>
+          </ThemedText>
 
           <TextInput
             label="Plant Name"

--- a/WeedGrowApp/app/add-plant/step3.tsx
+++ b/WeedGrowApp/app/add-plant/step3.tsx
@@ -20,6 +20,7 @@ import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { ThemedText } from '@/components/ThemedText';
 
 const screen = Dimensions.get('window');
 
@@ -154,9 +155,9 @@ export default function Step3() {
               </MapView>
             </View>
 
-            <Text style={{ color: Colors[theme].text, textAlign: 'center', marginTop: 8 }}>
+            <ThemedText style={{ textAlign: 'center', marginTop: 8 }}>
               Tap the map to adjust your location
-            </Text>
+            </ThemedText>
 
             <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 24 }}>
               <Button mode="outlined" onPress={() => router.back()}>

--- a/WeedGrowApp/app/add-plant/step4.tsx
+++ b/WeedGrowApp/app/add-plant/step4.tsx
@@ -16,6 +16,7 @@ import {
   Menu,
   Text,
 } from 'react-native-paper';
+import { ThemedText } from '@/components/ThemedText';
 import { useRouter } from 'expo-router';
 
 import StepIndicatorBar from '@/components/StepIndicatorBar';
@@ -89,7 +90,7 @@ export default function Step4() {
             style={inputStyle}
           />
 
-          <Text style={styles.sectionTitle}>Pest History</Text>
+          <ThemedText style={styles.sectionTitle}>Pest History</ThemedText>
           <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
             {pestOptions.map((p) => (
               <Chip
@@ -108,7 +109,7 @@ export default function Step4() {
             ))}
           </View>
 
-          <Text style={styles.sectionTitle}>Training Techniques</Text>
+          <ThemedText style={styles.sectionTitle}>Training Techniques</ThemedText>
           <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
             {trainingOptions.map((t) => (
               <Chip

--- a/WeedGrowApp/components/PlantCard.tsx
+++ b/WeedGrowApp/components/PlantCard.tsx
@@ -5,8 +5,10 @@ import { useRouter } from 'expo-router';
 
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
-import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { Plant } from '@/firestoreModels';
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 export interface PlantCardProps {
   plant: Plant & { id: string };
@@ -14,11 +16,13 @@ export interface PlantCardProps {
 
 export function PlantCard({ plant }: PlantCardProps) {
   const router = useRouter();
+  type Theme = keyof typeof Colors;
+  const theme = (useColorScheme() ?? 'dark') as Theme;
   return (
     <TouchableOpacity
       onPress={() => router.push({ pathname: '/plant/[id]', params: { id: plant.id } })}
     >
-      <ThemedView style={styles.card}>
+      <ThemedView style={[styles.card, { backgroundColor: Colors[theme].background }] }>
         {plant.imageUri && (
           <Animated.View
             sharedTransitionTag={`plant.${plant.id}.photo`}
@@ -29,9 +33,39 @@ export function PlantCard({ plant }: PlantCardProps) {
         )}
         <ThemedText type="subtitle">{plant.name}</ThemedText>
         <ThemedText>Strain: {plant.strain}</ThemedText>
-        <ThemedText><MaterialCommunityIcons name="sprout" size={16} color="#aaa" /> {plant.growthStage}</ThemedText>
-        <ThemedText><MaterialCommunityIcons name={plant.status === "active" ? "check-circle-outline" : plant.status === "archived" ? "archive" : plant.status === "harvested" ? "flower" : "skull"} size={16} color="#aaa" /> {plant.status}</ThemedText>
-        <ThemedText><MaterialCommunityIcons name={plant.environment === "indoor" ? "home" : plant.environment === "greenhouse" ? "greenhouse" : "tree"} size={16} color="#aaa" /> {plant.environment}</ThemedText>
+        <ThemedText>
+          <MaterialCommunityIcons name="sprout" size={16} color={Colors[theme].gray} /> {plant.growthStage}
+        </ThemedText>
+        <ThemedText>
+          <MaterialCommunityIcons
+            name={
+              plant.status === 'active'
+                ? 'check-circle-outline'
+                : plant.status === 'archived'
+                  ? 'archive'
+                  : plant.status === 'harvested'
+                    ? 'flower'
+                    : 'skull'
+            }
+            size={16}
+            color={Colors[theme].gray}
+          />{' '}
+          {plant.status}
+        </ThemedText>
+        <ThemedText>
+          <MaterialCommunityIcons
+            name={
+              plant.environment === 'indoor'
+                ? 'home'
+                : plant.environment === 'greenhouse'
+                  ? 'greenhouse'
+                  : 'tree'
+            }
+            size={16}
+            color={Colors[theme].gray}
+          />{' '}
+          {plant.environment}
+        </ThemedText>
       </ThemedView>
     </TouchableOpacity>
   );
@@ -41,7 +75,6 @@ const styles = StyleSheet.create({
   card: {
     marginBottom: 16,
     padding: 12,
-    backgroundColor: '#333',
     borderRadius: 8,
   },
   imageWrap: {


### PR DESCRIPTION
## Summary
- use app color palette on plant listing screen
- style plant cards with dark theme colors
- switch new plant steps to ThemedText for titles

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433de9e6808330bf2927d2e567d028