### PR TITLE
Move plant list to Plants tab

### DIFF
--- a/WeedGrowApp/app/(tabs)/plants.tsx
+++ b/WeedGrowApp/app/(tabs)/plants.tsx
@@ -1,32 +1,106 @@
-import React from 'react';
-import { StyleSheet, TouchableOpacity } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { StyleSheet, FlatList, TouchableOpacity } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { Colors } from '@/constants/Colors';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
-import { Colors } from '@/constants/Colors';
-import { useColorScheme } from '@/hooks/useColorScheme';
+import { PlantCard } from '@/components/PlantCard';
+import { collection, getDocs, query } from 'firebase/firestore';
+import { db } from '../../services/firebase';
+import { Plant } from '@/firestoreModels';
+import { ActivityIndicator } from 'react-native-paper';
+
+interface PlantItem extends Plant {
+  id: string;
+}
 
 export default function PlantsScreen() {
   const router = useRouter();
+  const [plants, setPlants] = useState<PlantItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   type Theme = keyof typeof Colors;
   const theme = (useColorScheme() ?? 'dark') as Theme;
+
+  useEffect(() => {
+    const fetchPlants = async () => {
+      try {
+        const plantsQuery = query(collection(db, 'plants'));
+        const snapshot = await getDocs(plantsQuery);
+        const items: PlantItem[] = snapshot.docs.map((doc) => ({
+          id: doc.id,
+          ...(doc.data() as Plant),
+        }));
+        setPlants(items);
+      } catch (e: any) {
+        console.error('Error fetching plants:', e);
+        setError(e.message || 'Unknown error');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchPlants();
+  }, []);
+
   return (
-    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <ThemedText type="title">Plants</ThemedText>
-      <TouchableOpacity
-        accessibilityLabel="Add Plant"
-        onPress={() => router.push('/add-plant')}
-        style={[styles.fab, { backgroundColor: Colors[theme].tint }]}
-      >
-        <MaterialCommunityIcons name="plus" size={28} color={Colors[theme].white} />
-      </TouchableOpacity>
-    </ThemedView>
+    <SafeAreaView style={[styles.safeArea, { backgroundColor: Colors[theme].background }]}>
+      <ThemedView style={styles.container}>
+        <ThemedText type="title" style={styles.title}>
+          My Plants
+        </ThemedText>
+        {loading && (
+          <ActivityIndicator style={styles.loading} color={Colors[theme].tint} />
+        )}
+        {error && (
+          <ThemedText type="error" style={[styles.errorText, { color: Colors[theme].tint }] }>
+            ❌ Error: {error}
+          </ThemedText>
+        )}
+        {!loading && !error && plants.length === 0 && (
+          <ThemedText>No plants found.</ThemedText>
+        )}
+        {!loading && !error && plants.length > 0 && (
+          <FlatList
+            data={plants}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item }) => <PlantCard plant={item} />}
+          />
+        )}
+        <TouchableOpacity
+          accessibilityLabel="Add Plant"
+          onPress={() => router.push('/add-plant')}
+          style={[styles.fab, { backgroundColor: Colors[theme].tint }]}
+        >
+          <MaterialCommunityIcons name="plus" size={28} color={Colors[theme].white} />
+        </TouchableOpacity>
+      </ThemedView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+  },
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  title: {
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  loading: {
+    marginTop: 20,
+  },
+  errorText: {
+    marginTop: 10,
+  },
   fab: {
     position: 'absolute',
     right: 20,


### PR DESCRIPTION
## Summary
- display plant list in the Plants tab
- keep floating add-plant button
- remove the old placeholder text

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684349cdd6e083308e783287f1f3c16c