### PR TITLE
Adjust card green to match calendar

### DIFF
--- a/WeedGrowApp/components/PlantCard.tsx
+++ b/WeedGrowApp/components/PlantCard.tsx
@@ -7,7 +7,7 @@ import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { Plant } from '@/firestoreModels';
-import { Colors } from '@/constants/Colors';
+import { Colors, calendarGreen } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
 export interface PlantCardProps {
@@ -23,7 +23,7 @@ export function PlantCard({ plant }: PlantCardProps) {
       onPress={() => router.push({ pathname: '/plant/[id]', params: { id: plant.id } })}
     >
       <ThemedView
-        style={[styles.card, { backgroundColor: Colors[theme].tint }]}
+        style={[styles.card, { backgroundColor: calendarGreen }]}
       >
         {plant.imageUri && (
           <Animated.View

--- a/WeedGrowApp/constants/Colors.ts
+++ b/WeedGrowApp/constants/Colors.ts
@@ -5,6 +5,8 @@
 
 const tintColorLight = '#00c853';
 const tintColorDark = '#00c853';
+// Dark green used by the calendar
+export const calendarGreen = '#008000';
 const grayColor = '#aaaaaa';
 const labelColor = '#999999';
 const whiteColor = '#ffffff';


### PR DESCRIPTION
## Summary
- revert general tint color to original
- expose calendarGreen constant
- apply calendarGreen only to plant cards
- restore web button colors

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm run lint` in weed-grow-web *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68434f14017883308ada31967077c699