### PR TITLE
Fix Step1 back button

### DIFF
--- a/WeedGrowApp/app/add-plant/step1.tsx
+++ b/WeedGrowApp/app/add-plant/step1.tsx
@@ -113,7 +113,10 @@ export default function Step1() {
           />
 
           <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 24 }}>
-            <Button mode="outlined" onPress={() => router.back()}>
+            <Button
+              mode="outlined"
+              onPress={() => router.replace('/(tabs)/plants')}
+            >
               Back
             </Button>
             <Button


### PR DESCRIPTION
## Summary
- fix back button on Add Plant Step1 to go back to the Plants tab

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434f7bf6ec833088ea8f60019cf047