### PR TITLE
Add search and filter to plant screen

### DIFF
--- a/WeedGrowApp/app/(tabs)/plants.tsx
+++ b/WeedGrowApp/app/(tabs)/plants.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { StyleSheet, FlatList, TouchableOpacity } from 'react-native';
+import { StyleSheet, FlatList, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
@@ -12,7 +12,7 @@ import { PlantCard } from '@/components/PlantCard';
 import { collection, getDocs, query } from 'firebase/firestore';
 import { db } from '../../services/firebase';
 import { Plant } from '@/firestoreModels';
-import { ActivityIndicator } from 'react-native-paper';
+import { ActivityIndicator, Searchbar, Menu, Button } from 'react-native-paper';
 
 interface PlantItem extends Plant {
   id: string;
@@ -23,6 +23,11 @@ export default function PlantsScreen() {
   const [plants, setPlants] = useState<PlantItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [statusFilter, setStatusFilter] = useState<string | null>(null);
+  const [envFilter, setEnvFilter] = useState<string | null>(null);
+  const [statusMenu, setStatusMenu] = useState(false);
+  const [envMenu, setEnvMenu] = useState(false);
   type Theme = keyof typeof Colors;
   const theme = (useColorScheme() ?? 'dark') as Theme;
 
@@ -47,12 +52,67 @@ export default function PlantsScreen() {
     fetchPlants();
   }, []);
 
+  const filteredPlants = plants.filter(
+    (p) =>
+      p.name.toLowerCase().includes(searchQuery.toLowerCase()) &&
+      (!statusFilter || p.status === statusFilter) &&
+      (!envFilter || p.environment === envFilter)
+  );
+
   return (
     <SafeAreaView style={[styles.safeArea, { backgroundColor: Colors[theme].background }]}>
       <ThemedView style={styles.container}>
         <ThemedText type="title" style={styles.title}>
           My Plants
         </ThemedText>
+        <Searchbar
+          placeholder="Search plants"
+          value={searchQuery}
+          onChangeText={setSearchQuery}
+          style={styles.searchBar}
+        />
+        <View style={styles.filterRow}>
+          <Menu
+            visible={statusMenu}
+            onDismiss={() => setStatusMenu(false)}
+            anchor={
+              <Button mode="outlined" onPress={() => setStatusMenu(true)}>
+                {statusFilter ? statusFilter : 'Status'}
+              </Button>
+            }
+          >
+            {['all', 'active', 'archived', 'harvested', 'dead'].map((opt) => (
+              <Menu.Item
+                key={opt}
+                onPress={() => {
+                  setStatusFilter(opt === 'all' ? null : opt);
+                  setStatusMenu(false);
+                }}
+                title={opt === 'all' ? 'All' : opt}
+              />
+            ))}
+          </Menu>
+          <Menu
+            visible={envMenu}
+            onDismiss={() => setEnvMenu(false)}
+            anchor={
+              <Button mode="outlined" onPress={() => setEnvMenu(true)}>
+                {envFilter ? envFilter : 'Environment'}
+              </Button>
+            }
+          >
+            {['all', 'outdoor', 'greenhouse', 'indoor'].map((opt) => (
+              <Menu.Item
+                key={opt}
+                onPress={() => {
+                  setEnvFilter(opt === 'all' ? null : opt);
+                  setEnvMenu(false);
+                }}
+                title={opt === 'all' ? 'All' : opt}
+              />
+            ))}
+          </Menu>
+        </View>
         {loading && (
           <ActivityIndicator style={styles.loading} color={Colors[theme].tint} />
         )}
@@ -64,12 +124,15 @@ export default function PlantsScreen() {
         {!loading && !error && plants.length === 0 && (
           <ThemedText>No plants found.</ThemedText>
         )}
-        {!loading && !error && plants.length > 0 && (
+        {!loading && !error && filteredPlants.length > 0 && (
           <FlatList
-            data={plants}
+            data={filteredPlants}
             keyExtractor={(item) => item.id}
             renderItem={({ item }) => <PlantCard plant={item} />}
           />
+        )}
+        {!loading && !error && filteredPlants.length === 0 && plants.length > 0 && (
+          <ThemedText>No plants match your filters.</ThemedText>
         )}
         <TouchableOpacity
           accessibilityLabel="Add Plant"
@@ -100,6 +163,14 @@ const styles = StyleSheet.create({
   },
   errorText: {
     marginTop: 10,
+  },
+  searchBar: {
+    marginBottom: 12,
+  },
+  filterRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 12,
   },
   fab: {
     position: 'absolute',


### PR DESCRIPTION
## Summary
- add search bar and filtering menus to plants screen

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435a40a0f08330ba654fd52fb3ea39