### PR TITLE
Implement plant card water and age info

### DIFF
--- a/WeedGrowApp/components/PlantCard.tsx
+++ b/WeedGrowApp/components/PlantCard.tsx
@@ -5,10 +5,10 @@ import { useRouter } from 'expo-router';
 
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
-import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { Plant } from '@/firestoreModels';
 import { Colors, calendarGreen } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { ProgressBar } from 'react-native-paper';
 
 export interface PlantCardProps {
   plant: Plant & { id: string };
@@ -18,6 +18,14 @@ export function PlantCard({ plant }: PlantCardProps) {
   const router = useRouter();
   type Theme = keyof typeof Colors;
   const theme = (useColorScheme() ?? 'dark') as Theme;
+
+  const createdDate =
+    'toDate' in plant.createdAt ? plant.createdAt.toDate() : (plant.createdAt as any);
+  const diffMs = Date.now() - new Date(createdDate).getTime();
+  const ageDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  const ageLabel = `${ageDays} day${ageDays === 1 ? '' : 's'} old`;
+
+  const waterLevel = typeof (plant as any).waterLevel === 'number' ? (plant as any).waterLevel : 0;
 
   return (
     <TouchableOpacity
@@ -36,41 +44,9 @@ export function PlantCard({ plant }: PlantCardProps) {
 
           <View style={styles.textContainer}>
             <ThemedText type="subtitle">{plant.name}</ThemedText>
-            <ThemedText>Strain: {plant.strain}</ThemedText>
-            <ThemedText>
-              <MaterialCommunityIcons name="sprout" size={16} color={Colors[theme].gray} />{' '}
-              {plant.growthStage}
-            </ThemedText>
-            <ThemedText>
-              <MaterialCommunityIcons
-                name={
-                  plant.status === 'active'
-                    ? 'check-circle-outline'
-                    : plant.status === 'archived'
-                    ? 'archive'
-                    : plant.status === 'harvested'
-                    ? 'flower'
-                    : 'skull'
-                }
-                size={16}
-                color={Colors[theme].gray}
-              />{' '}
-              {plant.status}
-            </ThemedText>
-            <ThemedText>
-              <MaterialCommunityIcons
-                name={
-                  plant.environment === 'indoor'
-                    ? 'home'
-                    : plant.environment === 'greenhouse'
-                    ? 'greenhouse'
-                    : 'tree'
-                }
-                size={16}
-                color={Colors[theme].gray}
-              />{' '}
-              {plant.environment}
-            </ThemedText>
+            <ThemedText>{plant.strain}</ThemedText>
+            <ThemedText>{ageLabel}</ThemedText>
+            <ProgressBar progress={waterLevel} style={styles.progressBar} color={Colors[theme].tint} />
           </View>
         </View>
       </ThemedView>
@@ -101,5 +77,10 @@ const styles = StyleSheet.create({
   textContainer: {
     flex: 1,
     gap: 4,
+  },
+  progressBar: {
+    marginTop: 4,
+    height: 8,
+    borderRadius: 4,
   },
 });

--- a/WeedGrowApp/firestoreModels.ts
+++ b/WeedGrowApp/firestoreModels.ts
@@ -20,6 +20,7 @@ export interface Plant {
     trainingTags?: string[];
     notes?: string;
     imageUri?: string;
+    waterLevel?: number; // 0-1 representing current watering level
   
     location?: {
       lat: number;

--- a/WeedGrowApp/seedFirestore.js
+++ b/WeedGrowApp/seedFirestore.js
@@ -84,6 +84,7 @@ async function seedFirestore() {
     pests: ["aphids"],
     notes: "Doing great so far.",
     imageUri: null, // or a URL to a primary plant image
+    waterLevel: 1,
     location: { lat: -34.0, lng: 18.5 },
     locationNickname: "Backyard",
     reminderSchedule: {


### PR DESCRIPTION
## Summary
- add progress bar for water level to PlantCard
- compute plant age from creation date
- extend `Plant` model with optional `waterLevel`
- seed example plant with `waterLevel`

## Testing
- `npx tsc -p WeedGrowApp/tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68436257f124833081e3179d4d7cd376