### PR TITLE
Add ageDays to stored plant data

### DIFF
--- a/WeedGrowApp/CONTEXT.md
+++ b/WeedGrowApp/CONTEXT.md
@@ -38,6 +38,7 @@ It helps Codex and other AI agents understand how your app stores and interacts 
   - `name: string`
   - `strain: string`
   - `growthStage: string`  // e.g. “germination”, “seedling”, etc.
+  - `ageDays?: number`  // current age of the plant in days
   - `status: string`  // e.g. “active” or “archived”
   - `environment: string`  // “indoor” or “outdoor”
   - `plantedIn: string`  // e.g. “pot”, “ground”

--- a/WeedGrowApp/app/add-plant/review.tsx
+++ b/WeedGrowApp/app/add-plant/review.tsx
@@ -9,7 +9,7 @@ import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
-import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
+import { collection, addDoc, serverTimestamp, Timestamp } from 'firebase/firestore';
 import { db } from '@/services/firebase';
 
 export default function Review() {
@@ -21,11 +21,14 @@ export default function Review() {
 
   const save = async () => {
     try {
+      const ageNum = parseInt(form.ageDays || '0', 10);
+      const createdAt = Timestamp.fromMillis(Date.now() - ageNum * 86400000);
       await addDoc(collection(db, 'plants'), {
         name: form.name,
         strain: form.strain,
         owners: ['demoUser'],
         growthStage: form.growthStage,
+        ageDays: ageNum,
         status: 'active',
         environment: form.environment,
         plantedIn: form.plantedIn,
@@ -39,7 +42,7 @@ export default function Review() {
         imageUri: form.imageUri ?? null,
         location: form.location ?? null,
         locationNickname: form.locationNickname ?? null,
-        createdAt: serverTimestamp(),
+        createdAt,
         updatedAt: serverTimestamp(),
       });
       form.reset();
@@ -79,6 +82,16 @@ export default function Review() {
               <Text variant="labelLarge">Growth Stage</Text>
               <Text>{form.growthStage}</Text>
             </View>
+
+            {(form.growthStage === 'vegetative' || form.growthStage === 'flowering') && (
+              <>
+                <Divider />
+                <View>
+                  <Text variant="labelLarge">Age (days)</Text>
+                  <Text>{form.ageDays}</Text>
+                </View>
+              </>
+            )}
 
             <Divider />
             <ThemedText style={styles.sectionTitle}>Environment</ThemedText>

--- a/WeedGrowApp/app/add-plant/step1.tsx
+++ b/WeedGrowApp/app/add-plant/step1.tsx
@@ -26,11 +26,15 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 
 export default function Step1() {
   const router = useRouter();
-  const { name, strain, growthStage, setField } = usePlantForm();
+  const { name, strain, growthStage, ageDays, setField } = usePlantForm();
   type Theme = keyof typeof Colors;
   const theme = (useColorScheme() ?? 'dark') as Theme;
   const insets = useSafeAreaInsets();
-  const isValid = name.trim().length > 0;
+  const isValid =
+    name.trim().length > 0 &&
+    ((growthStage === 'vegetative' || growthStage === 'flowering')
+      ? ageDays.trim().length > 0
+      : true);
   const [strainMenu, setStrainMenu] = React.useState(false);
   const [strainSearch, setStrainSearch] = React.useState('');
   const strains = ['Sativa', 'Indica', 'Hybrid'];
@@ -118,7 +122,12 @@ export default function Step1() {
 
             <SegmentedButtons
               value={growthStage}
-              onValueChange={(val) => setField('growthStage', val as any)}
+              onValueChange={(val) => {
+                setField('growthStage', val as any);
+                if (val === 'germination' || val === 'seedling') {
+                  setField('ageDays', '0');
+                }
+              }}
               buttons={[
                 { value: 'germination', label: 'Germination' },
                 { value: 'seedling', label: 'Seedling' },
@@ -126,6 +135,16 @@ export default function Step1() {
                 { value: 'flowering', label: 'Flowering' },
               ]}
             />
+
+            {(growthStage === 'vegetative' || growthStage === 'flowering') && (
+              <TextInput
+                label="Age in Days"
+                value={ageDays}
+                onChangeText={(text) => setField('ageDays', text)}
+                style={inputStyle}
+                keyboardType="numeric"
+              />
+            )}
 
             <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 24 }}>
               <Button

--- a/WeedGrowApp/firestoreModels.ts
+++ b/WeedGrowApp/firestoreModels.ts
@@ -8,6 +8,7 @@ export interface Plant {
     strain: string;
     owners: string[];
     growthStage: 'germination' | 'seedling' | 'vegetative' | 'flowering';
+    ageDays?: number;
     status: 'active' | 'archived' | 'harvested' | 'dead';
     environment: 'outdoor' | 'greenhouse' | 'indoor';
     plantedIn: 'pot' | 'ground';

--- a/WeedGrowApp/seedFirestore.js
+++ b/WeedGrowApp/seedFirestore.js
@@ -73,6 +73,7 @@ async function seedFirestore() {
     strain: "Indica",
     owners: [userId],
     growthStage: "germination",
+    ageDays: 0,
     status: "active",
     environment: "outdoor",
     plantedIn: "pot",

--- a/WeedGrowApp/stores/usePlantForm.ts
+++ b/WeedGrowApp/stores/usePlantForm.ts
@@ -8,6 +8,7 @@ export interface PlantFormState {
   name: string;
   strain: string;
   growthStage: GrowthStage;
+  ageDays: string;
   environment: Environment;
   potSize?: string;
   sunlightExposure?: string;
@@ -28,6 +29,7 @@ const initialState: Omit<PlantFormState, 'setField' | 'reset'> = {
   name: '',
   strain: '',
   growthStage: 'germination',
+  ageDays: '0',
   environment: 'outdoor',
   plantedIn: 'pot',
 };


### PR DESCRIPTION
## Summary
- store `ageDays` when saving a plant
- document `ageDays` in Firestore schema
- expose optional `ageDays` in Plant interface
- seed Firestore with `ageDays`

## Testing
- `npm run lint` in `WeedGrowApp` *(fails: expo not found)*
- `npm run lint` in `weed-grow-web` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6843655580e08330b6e2200db884a3f4