### PR TITLE
Implement collapsible list on More screen

### DIFF
--- a/WeedGrowApp/app/(tabs)/more.tsx
+++ b/WeedGrowApp/app/(tabs)/more.tsx
@@ -1,12 +1,78 @@
 import React from 'react';
-import { ThemedView } from '@/components/ThemedView';
+import { ScrollView, StyleSheet } from 'react-native';
+
+import { Collapsible } from '@/components/Collapsible';
 import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+
+const SECTIONS = [
+  {
+    title: 'Account & Security',
+    items: [
+      'Profile',
+      'Change Password',
+      'App Lock (PIN/Biometrics)',
+      'Language & Region',
+    ],
+  },
+  {
+    title: 'Preferences',
+    items: [
+      'Theme & Appearance',
+      'Units',
+      'Default Environment',
+      'Notifications',
+      'Reminder Schedule',
+    ],
+  },
+  {
+    title: 'Plant Management',
+    items: [
+      'My Shared Plants',
+      'Watering Calendar',
+      'Progress Gallery',
+      'Data Export',
+      'Backup & Restore',
+    ],
+  },
+  {
+    title: 'Community & Help',
+    items: ['Support / Feedback', 'FAQ', 'Share the App'],
+  },
+  {
+    title: 'Legal & About',
+    items: ['About WeedGrow', 'Terms of Service', 'Privacy Policy', 'Open Source'],
+  },
+  {
+    title: 'Account Actions',
+    items: ['Rate & Review', 'Sign Out', 'Delete Account'],
+  },
+];
 
 export default function MoreScreen() {
   return (
-    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <ThemedText type="title">More</ThemedText>
-      <ThemedText>Settings and more coming soon...</ThemedText>
+    <ThemedView style={{ flex: 1 }}>
+      <ScrollView contentContainerStyle={styles.container}>
+        {SECTIONS.map((section) => (
+          <Collapsible key={section.title} title={section.title}>
+            {section.items.map((item) => (
+              <ThemedText key={item} style={styles.itemText}>
+                {'\u2022'} {item}
+              </ThemedText>
+            ))}
+          </Collapsible>
+        ))}
+      </ScrollView>
     </ThemedView>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    gap: 12,
+  },
+  itemText: {
+    marginBottom: 4,
+  },
+});


### PR DESCRIPTION
## Summary
- expand the More tab into collapsible sections

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436ab0f30c8330b15262f24005670c