### PR TITLE
Fix review screen constant

### DIFF
--- a/WeedGrowApp/app/add-plant/review.tsx
+++ b/WeedGrowApp/app/add-plant/review.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'expo-router';
 import StepIndicatorBar from '@/components/StepIndicatorBar';
 import { usePlantForm } from '@/stores/usePlantForm';
 import { Colors } from '@/constants/Colors';
+import { MILLISECONDS_PER_DAY } from '@/constants/Time';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { collection, addDoc, serverTimestamp, Timestamp } from 'firebase/firestore';
 import { db } from '@/services/firebase';

--- a/WeedGrowApp/constants/Time.ts
+++ b/WeedGrowApp/constants/Time.ts
@@ -1,0 +1,1 @@
+export const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;


### PR DESCRIPTION
## Summary
- define `MILLISECONDS_PER_DAY` constant in a new `constants/Time.ts`
- import and use the new constant in `review.tsx`

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843739af2f08330b60935b651900ba1