### PR TITLE
Add weather utils stub

### DIFF
--- a/lib/weather/fetchWeather.ts
+++ b/lib/weather/fetchWeather.ts
@@ -1,0 +1,21 @@
+export async function fetchWeather(lat: number, lng: number): Promise<any> {
+  const env =
+    typeof import.meta !== 'undefined' && (import.meta as any).env
+      ? (import.meta as any).env
+      : process.env;
+
+  const apiKey = env.VITE_OPENWEATHERMAP_API_KEY || env.OPENWEATHERMAP_API_KEY;
+  if (!apiKey) {
+    throw new Error('OpenWeatherMap API key missing');
+  }
+
+  const baseUrl = 'https://api.openweathermap.org/data/3.0/onecall';
+  const url = `${baseUrl}?lat=${lat}&lon=${lng}&exclude=minutely,alerts&units=metric&appid=${apiKey}`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch weather data: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}

--- a/lib/weather/getPlantAdvice.ts
+++ b/lib/weather/getPlantAdvice.ts
@@ -1,0 +1,4 @@
+export function getPlantAdvice(): string {
+  // TODO: Provide advice based on weather and plant type
+  return 'Advice feature coming soon';
+}

--- a/lib/weather/parseWeatherData.ts
+++ b/lib/weather/parseWeatherData.ts
@@ -1,0 +1,4 @@
+export function parseWeatherData(data: any): any {
+  // TODO: Format and clean raw weather data
+  return data;
+}

--- a/lib/weather/updateFirestore.ts
+++ b/lib/weather/updateFirestore.ts
@@ -1,0 +1,10 @@
+import { db } from '../../firebase';
+
+export async function updateFirestore(
+  plantId: string,
+  date: string,
+  data: any
+): Promise<void> {
+  // TODO: Save parsed data per plant/date to Firestore
+  console.log('updateFirestore stub', plantId, date, data);
+}


### PR DESCRIPTION
## Summary
- set up `lib/weather` utilities folder
- implement `fetchWeather` using OpenWeatherMap API
- add placeholder modules for weather parsing, Firestore update, and advice

## Testing
- `npm run lint` in WeedGrowApp *(fails: `expo` not found)*
- `npm run lint` in weed-grow-web *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68444723880483309e0d8d1690a12c0a