### PR TITLE
Implement weather parsing and Firestore update

### DIFF
--- a/lib/weather/parseWeatherData.ts
+++ b/lib/weather/parseWeatherData.ts
@@ -1,4 +1,75 @@
-export function parseWeatherData(data: any): any {
-  // TODO: Format and clean raw weather data
-  return data;
+import { Timestamp } from 'firebase/firestore';
+import type { WeatherCacheEntry } from '../../WeedGrowApp/firestoreModels';
+
+/**
+ * Convert the OpenWeatherMap One Call API response into a map of
+ * `WeatherCacheEntry` objects keyed by date (YYYY-MM-DD).
+ */
+export function parseWeatherData(apiResponse: any): Record<string, WeatherCacheEntry> {
+  if (!apiResponse) return {};
+
+  const entries: Record<string, WeatherCacheEntry> = {};
+  const fetchedAt = Timestamp.now();
+  const tzOffset = apiResponse.timezone_offset ?? 0; // seconds
+
+  const toDateStr = (unix: number) =>
+    new Date((unix + tzOffset) * 1000).toISOString().split('T')[0];
+
+  const hourlyMap: Record<string, { peakTemp: number; rainHours: number }> = {};
+  if (Array.isArray(apiResponse.hourly)) {
+    for (const hour of apiResponse.hourly) {
+      const d = toDateStr(hour.dt);
+      const existing = hourlyMap[d] || { peakTemp: -Infinity, rainHours: 0 };
+      if (hour.temp > existing.peakTemp) existing.peakTemp = hour.temp;
+      const rainAmount = hour.rain?.['1h'] ?? hour.snow?.['1h'] ?? 0;
+      if (rainAmount > 0) existing.rainHours += 1;
+      hourlyMap[d] = existing;
+    }
+  }
+
+  const addEntry = (
+    dateStr: string,
+    forecasted: boolean,
+    sourceData: any
+  ) => {
+    const base: WeatherCacheEntry = {
+      date: dateStr,
+      fetchedAt,
+      forecasted,
+      source: 'OpenWeatherMap',
+      temperature: sourceData.temp?.day ?? sourceData.temp,
+      humidity: sourceData.humidity,
+      windSpeed: sourceData.wind_speed,
+      rainfall: sourceData.rain ?? sourceData.rainfall ?? 0,
+      uvIndex: sourceData.uvi,
+      weatherSummary: sourceData.weather?.[0]?.description ?? '',
+    };
+
+    const hourly = hourlyMap[dateStr];
+    if (hourly) {
+      base.hourlySummary = {
+        peakTemp: hourly.peakTemp,
+        rainHours: hourly.rainHours,
+      };
+    }
+
+    entries[dateStr] = base;
+  };
+
+  // Today from current conditions
+  if (apiResponse.current) {
+    const today = toDateStr(apiResponse.current.dt);
+    addEntry(today, false, apiResponse.current);
+  }
+
+  // Daily forecasts (daily[0] is today)
+  if (Array.isArray(apiResponse.daily)) {
+    apiResponse.daily.forEach((d: any, idx: number) => {
+      const dateStr = toDateStr(d.dt);
+      const forecasted = idx > 0; // index 0 overlaps with today
+      addEntry(dateStr, forecasted, d);
+    });
+  }
+
+  return entries;
 }

--- a/lib/weather/updateFirestore.ts
+++ b/lib/weather/updateFirestore.ts
@@ -1,10 +1,22 @@
+import { doc, setDoc } from 'firebase/firestore';
 import { db } from '../../firebase';
+import type { WeatherCacheEntry } from '../../WeedGrowApp/firestoreModels';
 
-export async function updateFirestore(
+/**
+ * Persist parsed weather data for a plant.
+ * Each key of `parsedData` is a date (YYYY-MM-DD) with a `WeatherCacheEntry`.
+ * The document is merged with any existing data so future runs can append.
+ */
+export async function updateWeatherCache(
   plantId: string,
-  date: string,
-  data: any
+  parsedData: Record<string, WeatherCacheEntry>
 ): Promise<void> {
-  // TODO: Save parsed data per plant/date to Firestore
-  console.log('updateFirestore stub', plantId, date, data);
+  const updates = Object.entries(parsedData).map(([date, entry]) =>
+    setDoc(
+      doc(db, 'plants', plantId, 'weatherCache', date),
+      entry,
+      { merge: true }
+    )
+  );
+  await Promise.all(updates);
 }


### PR DESCRIPTION
## Summary
- parse OpenWeatherMap response into `WeatherCacheEntry` records
- save parsed weather data per plant/date with merge semantics

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684448262fb08330a65bd0d81711abb2