### PR TITLE
Extend weather cache fields

### DIFF
--- a/WeedGrowApp/CONTEXT.md
+++ b/WeedGrowApp/CONTEXT.md
@@ -86,6 +86,12 @@ Fields:
 - `uvIndex`: number
 - `weatherSummary`: string
 - `hourlySummary` (optional): { peakTemp: number, rainHours: number }
+- `dewPoint` (optional): number
+- `cloudCoverage` (optional): number
+- `windGust` (optional): number
+- `sunrise` (optional): string
+- `sunset` (optional): string
+- `pop` (optional): number // Probability of precipitation
 
 ### **`/plants/{plantId}/progressPics/{picId}`**  ← *NEW*
 - Subcollection for storing progress pictures of each plant.

--- a/WeedGrowApp/firestoreModels.ts
+++ b/WeedGrowApp/firestoreModels.ts
@@ -69,6 +69,12 @@ export interface WeatherCacheEntry {
       peakTemp: number;
       rainHours: number;
     };
+    dewPoint?: number;
+    cloudCoverage?: number;
+    windGust?: number;
+    sunrise?: string;
+    sunset?: string;
+    pop?: number;
 }
   
   // ================================

--- a/WeedGrowApp/lib/weather/parseWeatherData.ts
+++ b/WeedGrowApp/lib/weather/parseWeatherData.ts
@@ -43,6 +43,16 @@ export function parseWeatherData(apiResponse: any): Record<string, WeatherCacheE
       rainfall: sourceData.rain ?? sourceData.rainfall ?? 0,
       uvIndex: sourceData.uvi,
       weatherSummary: sourceData.weather?.[0]?.description ?? '',
+      dewPoint: sourceData.dew_point,
+      cloudCoverage: sourceData.clouds,
+      windGust: sourceData.wind_gust,
+      sunrise: sourceData.sunrise
+        ? new Date((sourceData.sunrise + tzOffset) * 1000).toISOString()
+        : undefined,
+      sunset: sourceData.sunset
+        ? new Date((sourceData.sunset + tzOffset) * 1000).toISOString()
+        : undefined,
+      pop: sourceData.pop,
     };
 
     const hourly = hourlyMap[dateStr];

--- a/WeedGrowApp/seedFirestore.js
+++ b/WeedGrowApp/seedFirestore.js
@@ -122,6 +122,12 @@ async function seedFirestore() {
       uvIndex: 5,
       windSpeed: "10 km/h",
       summary: "Sunny and mild",
+      dewPoint: "12°C",
+      cloudCoverage: 20,
+      windGust: "15 km/h",
+      sunrise: "06:15",
+      sunset: "18:35",
+      pop: 0.1,
       fetchedAt: now,
     });
 

--- a/WeedGrowApp/seedFirestore.ts
+++ b/WeedGrowApp/seedFirestore.ts
@@ -133,6 +133,12 @@ async function seedFirestore() {
       uvIndex: 4,
       weatherSummary: "Partly cloudy",
       hourlySummary: { peakTemp: 21, rainHours: 1 },
+      dewPoint: 12,
+      cloudCoverage: 40,
+      windGust: 12,
+      sunrise: "06:10",
+      sunset: "18:30",
+      pop: 0.2,
     },
     {
       date: fmt(today),
@@ -145,6 +151,12 @@ async function seedFirestore() {
       uvIndex: 6,
       weatherSummary: "Sunny and warm",
       hourlySummary: { peakTemp: 23, rainHours: 0 },
+      dewPoint: 13,
+      cloudCoverage: 20,
+      windGust: 15,
+      sunrise: "06:15",
+      sunset: "18:35",
+      pop: 0.1,
     },
     {
       date: fmt(tomorrow),
@@ -157,6 +169,12 @@ async function seedFirestore() {
       uvIndex: 3,
       weatherSummary: "Expected showers",
       hourlySummary: { peakTemp: 20, rainHours: 3 },
+      dewPoint: 11,
+      cloudCoverage: 80,
+      windGust: 30,
+      sunrise: "06:20",
+      sunset: "18:40",
+      pop: 0.7,
     },
   ];
 


### PR DESCRIPTION
## Summary
- update `WeatherCacheEntry` with new optional weather fields
- parse new fields from OpenWeatherMap API
- seed Firestore with new weather fields for sample data
- document additional weather cache fields

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm run lint` in `weed-grow-web` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6844757247f48330b8a79d2a8e0d8613