### PR TITLE
Add watering suggestion utility

### DIFF
--- a/WeedGrowApp/components/PlantCard.tsx
+++ b/WeedGrowApp/components/PlantCard.tsx
@@ -7,18 +7,15 @@ import { Plant } from '@/firestoreModels';
 import { Colors, calendarGreen } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { getWateringSuggestion, Weather } from '@/utils/watering';
 
 export interface PlantCardProps {
   plant: Plant & { id: string };
-  weather?: {
-    rainToday: boolean;
-    rainTomorrow: boolean;
-    humidity: number;
-  };
+  weather?: Weather;
 }
 
 export function PlantCard({ plant, weather }: PlantCardProps) {
-  const defaultWeather = {
+  const defaultWeather: Weather = {
     rainToday: false,
     rainTomorrow: false,
     humidity: 50,
@@ -29,16 +26,7 @@ export function PlantCard({ plant, weather }: PlantCardProps) {
   type Theme = keyof typeof Colors;
   const theme = (useColorScheme() ?? 'dark') as Theme;
 
-  const lastWateredAt = new Date((plant as any).lastWateredAt ?? 0);
-  const daysSinceWatered = Math.floor((Date.now() - lastWateredAt.getTime()) / (1000 * 60 * 60 * 24));
-  const frequency = (plant as any).wateringFrequency ?? 3;
-
-  const getWateringSuggestion = () => {
-    if (currentWeather.rainToday) return 'Rain Incoming';
-    if (daysSinceWatered > frequency && !currentWeather.rainTomorrow) return 'Water Today';
-    if (currentWeather.rainTomorrow || daysSinceWatered === frequency) return 'Water Lightly';
-    return 'No Water Needed';
-  };
+  const suggestion = getWateringSuggestion(plant, currentWeather);
 
   const getSuggestionColor = (suggestion: string) => {
     switch (suggestion) {
@@ -64,7 +52,6 @@ export function PlantCard({ plant, weather }: PlantCardProps) {
     }
   };
 
-  const suggestion = getWateringSuggestion();
   const suggestionColor = getSuggestionColor(suggestion);
   const borderColor = getBorderColor(suggestion);
 

--- a/WeedGrowApp/utils/watering.ts
+++ b/WeedGrowApp/utils/watering.ts
@@ -1,0 +1,49 @@
+import { Plant } from '@/firestoreModels';
+
+export interface Weather {
+  rainToday: boolean;
+  rainTomorrow: boolean;
+  rainfallYesterday?: number;
+  humidity?: number;
+}
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+function parseFrequencyToDays(freq: unknown): number | null {
+  if (!freq) return null;
+  if (typeof freq === 'number') return freq;
+  const str = String(freq).toLowerCase();
+  const match = str.match(/(\d+)/);
+  if (match) return parseInt(match[1], 10);
+  if (str.includes('day')) return 1;
+  if (str.includes('week')) return 7;
+  return null;
+}
+
+function estimateLastWatered(createdAt: Date, freqDays: number): Date {
+  const daysSinceCreated = Math.floor((Date.now() - createdAt.getTime()) / DAY_MS);
+  const cycles = Math.floor(daysSinceCreated / freqDays);
+  return new Date(createdAt.getTime() + cycles * freqDays * DAY_MS);
+}
+
+export function getWateringSuggestion(plant: Plant, weather: Weather): string {
+  const freqDays = parseFrequencyToDays((plant as any).wateringFrequency);
+  if (!freqDays) return 'No Water History';
+
+  let lastWatered: Date | null = null;
+  if ((plant as any).lastWateredAt) {
+    lastWatered = new Date((plant as any).lastWateredAt);
+  } else if (plant.createdAt) {
+    lastWatered = estimateLastWatered(new Date(plant.createdAt as any), freqDays);
+  }
+
+  if (!lastWatered) return 'No Water History';
+
+  const daysSince = Math.floor((Date.now() - lastWatered.getTime()) / DAY_MS);
+  const isTimeToWater = daysSince >= freqDays;
+
+  if (weather.rainToday) return 'Rain Incoming';
+  if (isTimeToWater && weather.rainTomorrow) return 'Water Lightly';
+  if (isTimeToWater) return 'Water Today';
+  return 'No Water Needed';
+}

--- a/WeedGrowApp/utils/watering.ts
+++ b/WeedGrowApp/utils/watering.ts
@@ -27,14 +27,14 @@ function estimateLastWatered(createdAt: Date, freqDays: number): Date {
 }
 
 export function getWateringSuggestion(plant: Plant, weather: Weather): string {
-  const freqDays = parseFrequencyToDays((plant as any).wateringFrequency);
+  const freqDays = parseFrequencyToDays(plant.wateringFrequency);
   if (!freqDays) return 'No Water History';
 
   let lastWatered: Date | null = null;
-  if ((plant as any).lastWateredAt) {
-    lastWatered = new Date((plant as any).lastWateredAt);
+  if (plant.lastWateredAt) {
+    lastWatered = new Date(plant.lastWateredAt);
   } else if (plant.createdAt) {
-    lastWatered = estimateLastWatered(new Date(plant.createdAt as any), freqDays);
+    lastWatered = estimateLastWatered(new Date(plant.createdAt), freqDays);
   }
 
   if (!lastWatered) return 'No Water History';


### PR DESCRIPTION
## Summary
- add `getWateringSuggestion` in `utils/watering.ts`
- use utility in `PlantCard` for consistent watering advice

## Testing
- `npm -C WeedGrowApp run lint` *(fails: expo not found)*
- `npm -C weed-grow-web run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6844b130df5c8330babd915c57f630a1