### PR TITLE
Implement getPlantAdvice logic

### DIFF
--- a/WeedGrowApp/lib/weather/getPlantAdvice.ts
+++ b/WeedGrowApp/lib/weather/getPlantAdvice.ts
@@ -1,4 +1,87 @@
-export function getPlantAdvice(): string {
-  // TODO: Provide advice based on weather and plant type
-  return 'Advice feature coming soon';
+export interface PlantAdviceContext {
+  /** Days since the plant was last watered */
+  daysSinceWatered: number;
+  /** Desired watering frequency in days */
+  frequency: number;
+  /** Will it rain today? */
+  rainToday: boolean;
+  /** Will it rain tomorrow? */
+  rainTomorrow: boolean;
+  /** Rainfall yesterday in millimetres */
+  rainYesterday?: number;
+  /** Current humidity percentage */
+  humidity: number;
+  /** Current dew point in °C */
+  dewPoint: number;
+  /** Cloud coverage percentage */
+  cloudCoverage: number;
+  /** Wind gust speed in km/h */
+  windGust: number;
+  /** Probability of precipitation percentage */
+  pop: number;
+}
+
+/**
+ * Return a short piece of advice based on watering history and upcoming weather.
+ */
+export function getPlantAdvice(ctx: PlantAdviceContext): string {
+  const {
+    daysSinceWatered,
+    frequency,
+    rainToday,
+    rainTomorrow,
+    rainYesterday = 0,
+    humidity,
+    dewPoint,
+    cloudCoverage,
+    windGust,
+    pop,
+  } = ctx;
+
+  // 1. Rain expected today
+  if (rainToday) {
+    return 'Rain incoming – no need to water.';
+  }
+
+  // 2. Rain expected tomorrow
+  if (rainTomorrow && !rainToday && daysSinceWatered < frequency) {
+    return 'Rain is expected tomorrow – delay watering unless soil looks dry.';
+  }
+
+  // 3. It rained yesterday
+  if (rainYesterday > 2) {
+    return 'Recent rain – soil may still be moist.';
+  }
+
+  // 6. High humidity + cloud cover = mildew risk
+  if (humidity > 85 && dewPoint > 16 && cloudCoverage > 70) {
+    return 'High mildew risk – avoid watering today.';
+  }
+
+  // 4. Hot & dry conditions (with watering overdue)
+  if (daysSinceWatered >= frequency && humidity < 50 && !rainToday) {
+    return 'Dry weather – water your plant today.';
+  }
+
+  // 5. Mildly dry, but rain might come
+  if (daysSinceWatered === frequency && pop > 40) {
+    return 'Rain might come – water lightly if soil feels dry.';
+  }
+
+  // 7. High wind conditions
+  if (windGust > 30) {
+    return 'High winds today – check your plant is stable.';
+  }
+
+  // 8. Watering overdue but weather not ideal
+  if (daysSinceWatered > frequency && (rainTomorrow || humidity > 80)) {
+    return "Watering is overdue, but conditions aren’t ideal. Water lightly or wait.";
+  }
+
+  // 9. Everything is balanced
+  if (daysSinceWatered < frequency) {
+    return 'All good – no watering needed today.';
+  }
+
+  return 'No specific advice available.';
 }

--- a/WeedGrowApp/lib/weather/getPlantAdvice.ts
+++ b/WeedGrowApp/lib/weather/getPlantAdvice.ts
@@ -21,6 +21,11 @@ export interface PlantAdviceContext {
   pop: number;
 }
 
+// Thresholds for mildew risk checks
+const MILDEW_HUMIDITY_THRESHOLD = 85;
+const MILDEW_DEWPOINT_THRESHOLD = 16;
+const MILDEW_CLOUD_COVERAGE_THRESHOLD = 70;
+
 /**
  * Return a short piece of advice based on watering history and upcoming weather.
  */
@@ -54,7 +59,11 @@ export function getPlantAdvice(ctx: PlantAdviceContext): string {
   }
 
   // 6. High humidity + cloud cover = mildew risk
-  if (humidity > 85 && dewPoint > 16 && cloudCoverage > 70) {
+  if (
+    humidity > MILDEW_HUMIDITY_THRESHOLD &&
+    dewPoint > MILDEW_DEWPOINT_THRESHOLD &&
+    cloudCoverage > MILDEW_CLOUD_COVERAGE_THRESHOLD
+  ) {
     return 'High mildew risk – avoid watering today.';
   }
 


### PR DESCRIPTION
## Summary
- implement `getPlantAdvice` with weather scenarios

## Testing
- `npm run lint` in `WeedGrowApp` *(fails: `expo` not found)*
- `npm run lint` in `weed-grow-web` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6844b446948883308cc2c29deee902e1