### PR TITLE
Display weather bar for plants

### DIFF
--- a/WeedGrowApp/components/WeatherBar.tsx
+++ b/WeedGrowApp/components/WeatherBar.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { ThemedText } from '@/components/ThemedText';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { Colors } from '@/constants/Colors';
+import type { WeatherCacheEntry } from '@/firestoreModels';
+
+export interface WeatherBarProps {
+  /**
+   * Array of weather entries for 4 consecutive days
+   * starting yesterday.
+   */
+  data: (WeatherCacheEntry | null)[];
+}
+
+export default function WeatherBar({ data }: WeatherBarProps) {
+  const theme = (useColorScheme() ?? 'dark') as keyof typeof Colors;
+  const labels = ['Yesterday', 'Today', 'Tomorrow', 'Day +2'];
+
+  return (
+    <View style={styles.container}>
+      {data.map((entry, idx) => (
+        <View key={idx} style={styles.day}>
+          <MaterialCommunityIcons
+            name={entry && entry.rainfall > 0 ? 'weather-rainy' : 'weather-sunny'}
+            size={24}
+            color={Colors[theme].tint}
+          />
+          <ThemedText style={styles.label}>{labels[idx]}</ThemedText>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    marginTop: 8,
+  },
+  day: {
+    alignItems: 'center',
+  },
+  label: {
+    marginTop: 4,
+  },
+});


### PR DESCRIPTION
## Summary
- show a 4‑day weather bar for each plant

## Testing
- `npm run lint` *(fails: `expo` not found)*
- `npm run lint` in `weed-grow-web` *(fails: cannot find `@eslint/js`)*
- `npx tsc -p WeedGrowApp/tsconfig.json` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6844bbe47a188330817b09e466b26e7d