### PR TITLE
Add status tooltip to PlantCard

### DIFF
--- a/WeedGrowApp/components/InfoTooltip.tsx
+++ b/WeedGrowApp/components/InfoTooltip.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export function InfoTooltip({ message }: { message: string }) {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity
+        onPress={(ev) => {
+          ev.stopPropagation();
+          setVisible((v) => !v);
+        }}
+        accessibilityLabel="Show advice reason"
+      >
+        <MaterialCommunityIcons name="information" size={16} />
+      </TouchableOpacity>
+      {visible && (
+        <ThemedView style={styles.tooltip}>
+          <ThemedText style={styles.tooltipText}>{message}</ThemedText>
+        </ThemedView>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginLeft: 4,
+  },
+  tooltip: {
+    position: 'absolute',
+    top: 20,
+    left: 0,
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+    borderRadius: 6,
+    backgroundColor: '#333',
+    zIndex: 20,
+    maxWidth: 200,
+  },
+  tooltipText: {
+    color: 'white',
+    fontSize: 12,
+  },
+});

--- a/WeedGrowApp/components/PlantCard.tsx
+++ b/WeedGrowApp/components/PlantCard.tsx
@@ -6,7 +6,8 @@ import { ThemedText } from '@/components/ThemedText';
 import { Plant } from '@/firestoreModels';
 import { calendarGreen } from '@/constants/Colors';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
-import { getPlantAdvice, PlantAdviceContext } from '@/lib/weather/getPlantAdvice';
+import { getPlantAdviceWithReason, PlantAdviceContext } from '@/lib/weather/getPlantAdvice';
+import { InfoTooltip } from '@/components/InfoTooltip';
 
 export interface PlantCardProps {
   plant: Plant & { id: string };
@@ -27,7 +28,7 @@ export function PlantCard({ plant, weather }: PlantCardProps) {
     pop: weather?.pop ?? 0.2,
   };
 
-  const advice = getPlantAdvice(ctx);
+  const { advice, reason } = getPlantAdviceWithReason(ctx);
 
   const getSuggestionColor = () => {
     if (advice.includes('mildew')) return '#DC2626'; // red
@@ -52,6 +53,7 @@ export function PlantCard({ plant, weather }: PlantCardProps) {
     greenhouse: 'greenhouse',
   }[(plant as any).environment ?? 'indoor'];
 
+
   return (
     <TouchableOpacity
       onPress={() => router.push({ pathname: '/plant/[id]', params: { id: plant.id } })}
@@ -66,8 +68,14 @@ export function PlantCard({ plant, weather }: PlantCardProps) {
             <ThemedText>
               {(plant as any).strain} | <MaterialCommunityIcons name={envIcon} size={14} />
             </ThemedText>
-            <View style={[styles.suggestionChip, { backgroundColor: suggestionColor }]}>
-              <ThemedText style={styles.suggestionText}>{advice}</ThemedText>
+            <View style={styles.statusRow}>
+              <ThemedText>{plant.status}</ThemedText>
+            </View>
+            <View style={styles.suggestionRow}>
+              <View style={[styles.suggestionChip, { backgroundColor: suggestionColor }]}>
+                <ThemedText style={styles.suggestionText}>{advice}</ThemedText>
+              </View>
+              <InfoTooltip message={reason} />
             </View>
           </View>
         </View>
@@ -97,6 +105,16 @@ const styles = StyleSheet.create({
   textContainer: {
     flex: 1,
     gap: 6,
+  },
+  statusRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  suggestionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
   },
   suggestionChip: {
     alignSelf: 'flex-start',

--- a/WeedGrowApp/lib/weather/getPlantAdvice.ts
+++ b/WeedGrowApp/lib/weather/getPlantAdvice.ts
@@ -25,7 +25,13 @@ const MILDEW_CLOUD_COVERAGE_THRESHOLD = 70;
 /**
  * Return a short piece of advice based on watering history and upcoming weather.
  */
-export function getPlantAdvice(ctx: PlantAdviceContext): string {
+export interface PlantAdviceResult {
+  advice: string;
+  /** Brief explanation of why this advice was chosen */
+  reason: string;
+}
+
+export function getPlantAdviceWithReason(ctx: PlantAdviceContext): PlantAdviceResult {
   const {
     rainToday,
     rainTomorrow,
@@ -39,17 +45,26 @@ export function getPlantAdvice(ctx: PlantAdviceContext): string {
 
   // 1. Rain expected today
   if (rainToday) {
-    return 'Rain incoming – no need to water.';
+    return {
+      advice: 'Rain incoming – no need to water.',
+      reason: 'Rain is forecast today, so watering isn\'t necessary.',
+    };
   }
 
   // 2. Rain expected tomorrow
   if (rainTomorrow && !rainToday) {
-    return 'Rain is expected tomorrow – delay watering unless soil looks dry.';
+    return {
+      advice: 'Rain is expected tomorrow – delay watering unless soil looks dry.',
+      reason: 'Rain is expected tomorrow and none today, so you can hold off watering.',
+    };
   }
 
   // 3. It rained yesterday
   if (rainYesterday > 2) {
-    return 'Recent rain – soil may still be moist.';
+    return {
+      advice: 'Recent rain – soil may still be moist.',
+      reason: 'There was significant rain yesterday which likely left the soil damp.',
+    };
   }
 
   // 6. High humidity + cloud cover = mildew risk
@@ -58,28 +73,53 @@ export function getPlantAdvice(ctx: PlantAdviceContext): string {
     dewPoint > MILDEW_DEWPOINT_THRESHOLD &&
     cloudCoverage > MILDEW_CLOUD_COVERAGE_THRESHOLD
   ) {
-    return 'High mildew risk – avoid watering today.';
+    return {
+      advice: 'High mildew risk – avoid watering today.',
+      reason: 'Humidity, dew point and cloud cover are high, increasing mildew risk.',
+    };
   }
 
   // 4. Hot & dry conditions
   if (humidity < 50 && !rainToday) {
-    return 'Dry weather – water your plant today.';
+    return {
+      advice: 'Dry weather – water your plant today.',
+      reason: 'Low humidity and no rain can dry the soil quickly.',
+    };
   }
 
   // 5. Mildly dry, but rain might come
   if (pop > 0.4) {
-    return 'Rain might come – water lightly if soil feels dry.';
+    return {
+      advice: 'Rain might come – water lightly if soil feels dry.',
+      reason: 'There is a moderate chance of precipitation soon.',
+    };
   }
 
   // 7. High wind conditions
   if (windGust > 30) {
-    return 'High winds today – check your plant is stable.';
+    return {
+      advice: 'High winds today – check your plant is stable.',
+      reason: 'Strong winds can stress or topple plants.',
+    };
   }
 
   // 8. Very humid but no rain
   if (humidity > 80 && !rainToday && !rainTomorrow) {
-    return 'Very humid conditions – avoid heavy watering.';
+    return {
+      advice: 'Very humid conditions – avoid heavy watering.',
+      reason: 'Humidity is high but no rain is expected, which could promote fungus.',
+    };
   }
 
-  return 'Your plant might need water – check the soil.';
+  return {
+    advice: 'Your plant might need water – check the soil.',
+    reason: 'No specific conditions met, so check the soil for dryness.',
+  };
+}
+
+/**
+ * Backwards-compatible helper that returns only the advice string.
+ */
+export function getPlantAdvice(ctx: PlantAdviceContext): string {
+  return getPlantAdviceWithReason(ctx).advice;
 }


### PR DESCRIPTION
## Summary
- add tooltip with explanation for the watering advice
- expose `getPlantAdviceWithReason` helper

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844c37e98ac83308c1fc44727f7c9d6