### PR TITLE
Fix tooltip alignment

### DIFF
--- a/WeedGrowApp/components/InfoTooltip.tsx
+++ b/WeedGrowApp/components/InfoTooltip.tsx
@@ -34,7 +34,7 @@ const styles = StyleSheet.create({
   tooltip: {
     position: 'absolute',
     top: 20,
-    left: 0,
+    right: 0,
     paddingVertical: 4,
     paddingHorizontal: 8,
     borderRadius: 6,


### PR DESCRIPTION
## Summary
- set tooltip position to `right: 0` so it doesn't overflow on the PlantCard

## Testing
- `npm run lint` (fails: `expo` not found)
- `npm run lint` in `weed-grow-web` (fails: cannot find `@eslint/js`)

------
https://chatgpt.com/codex/tasks/task_e_6844c5b90c4483309473052dbb72f5e2