### PR TITLE
Fix tooltip overflow and resize suggestion chip

### DIFF
--- a/WeedGrowApp/components/InfoTooltip.tsx
+++ b/WeedGrowApp/components/InfoTooltip.tsx
@@ -15,10 +15,11 @@ export function InfoTooltip({ message }: { message: string }) {
           setVisible((v) => !v);
         }}
         accessibilityLabel="Show advice reason"
+        style={styles.iconWrapper}
       >
         <MaterialCommunityIcons
           name="information"
-          size={16}
+          size={20}
           color="#ea580c"
         />
       </TouchableOpacity>
@@ -36,10 +37,13 @@ const styles = StyleSheet.create({
     marginLeft: 4,
     position: 'relative',
   },
+  iconWrapper: {
+    padding: 4,
+  },
   tooltip: {
     position: 'absolute',
     top: -4,
-    left: 20,
+    right: 24,
     paddingVertical: 4,
     paddingHorizontal: 8,
     borderRadius: 6,

--- a/WeedGrowApp/components/PlantCard.tsx
+++ b/WeedGrowApp/components/PlantCard.tsx
@@ -119,9 +119,9 @@ const styles = StyleSheet.create({
   },
   suggestionChip: {
     alignSelf: 'flex-start',
-    paddingVertical: 4,
-    paddingHorizontal: 8,
-    borderRadius: 12,
+    paddingVertical: 2,
+    paddingHorizontal: 6,
+    borderRadius: 8,
     marginTop: 4,
   },
   suggestionText: {


### PR DESCRIPTION
## Summary
- keep tooltip inside the screen by anchoring it to the right of the icon
- enlarge the tooltip touch target
- shrink suggestion chip padding so the tooltip has room

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm run lint` in `weed-grow-web` *(fails: @eslint/js missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844c9440fb4833085a7d29ccb450ac8