### PR TITLE
Position tooltip below suggestion box

### DIFF
--- a/WeedGrowApp/components/InfoTooltip.tsx
+++ b/WeedGrowApp/components/InfoTooltip.tsx
@@ -42,8 +42,9 @@ const styles = StyleSheet.create({
   },
   tooltip: {
     position: 'absolute',
-    top: -4,
-    right: 24,
+    top: '100%',
+    left: 0,
+    marginTop: 4,
     paddingVertical: 4,
     paddingHorizontal: 8,
     borderRadius: 6,


### PR DESCRIPTION
## Summary
- reposition tooltip below the suggestion chip

## Testing
- `npm run lint` (fails: expo not found)
- `npm run lint` in `weed-grow-web` (fails: cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_6844cb91aefc833093eafc0b211e1b85