### PR TITLE
Replace tooltip with button

### DIFF
--- a/WeedGrowApp/components/InfoTooltip.tsx
+++ b/WeedGrowApp/components/InfoTooltip.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
-import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
 
@@ -15,17 +14,13 @@ export function InfoTooltip({ message }: { message: string }) {
           setVisible((v) => !v);
         }}
         accessibilityLabel="Show advice reason"
-        style={styles.iconWrapper}
+        style={styles.button}
       >
-        <MaterialCommunityIcons
-          name="information"
-          size={20}
-          color="#ea580c"
-        />
+        <ThemedText style={styles.buttonText}>Why?</ThemedText>
       </TouchableOpacity>
       {visible && (
-        <ThemedView style={styles.tooltip}>
-          <ThemedText style={styles.tooltipText}>{message}</ThemedText>
+        <ThemedView style={styles.messageBox}>
+          <ThemedText style={styles.messageText}>{message}</ThemedText>
         </ThemedView>
       )}
     </View>
@@ -35,24 +30,26 @@ export function InfoTooltip({ message }: { message: string }) {
 const styles = StyleSheet.create({
   container: {
     marginLeft: 4,
-    position: 'relative',
-  },
-  iconWrapper: {
-    padding: 4,
-  },
-  tooltip: {
-    position: 'absolute',
-    top: '100%',
-    left: 0,
     marginTop: 4,
-    paddingVertical: 4,
-    paddingHorizontal: 8,
+    alignSelf: 'flex-start',
+  },
+  button: {
+    paddingVertical: 2,
+    paddingHorizontal: 6,
     borderRadius: 6,
     backgroundColor: '#ea580c',
-    zIndex: 20,
-    maxWidth: 200,
   },
-  tooltipText: {
+  buttonText: {
+    color: 'white',
+    fontSize: 12,
+  },
+  messageBox: {
+    marginTop: 4,
+    padding: 8,
+    borderRadius: 6,
+    backgroundColor: '#ea580c',
+  },
+  messageText: {
     color: 'white',
     fontSize: 12,
   },

--- a/WeedGrowApp/components/PlantCard.tsx
+++ b/WeedGrowApp/components/PlantCard.tsx
@@ -72,11 +72,11 @@ export function PlantCard({ plant, weather }: PlantCardProps) {
               <ThemedText>{plant.status}</ThemedText>
             </View>
             <View style={styles.suggestionRow}>
-              <View style={[styles.suggestionChip, { backgroundColor: suggestionColor }]}>
+              <View style={[styles.suggestionChip, { backgroundColor: suggestionColor }]}> 
                 <ThemedText style={styles.suggestionText}>{advice}</ThemedText>
               </View>
-              <InfoTooltip message={reason} />
             </View>
+            <InfoTooltip message={reason} />
           </View>
         </View>
       </ThemedView>
@@ -115,7 +115,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 4,
-    position: 'relative',
   },
   suggestionChip: {
     alignSelf: 'flex-start',


### PR DESCRIPTION
## Summary
- rework InfoTooltip into a button
- position the new button below the suggestion chip on the PlantCard

## Testing
- `npm run lint` (fails: expo not found)
- `npm run lint` in weed-grow-web (fails: cannot find '@eslint/js')
- `npx tsc --noEmit` (fails: missing expo modules)


------
https://chatgpt.com/codex/tasks/task_e_6844cd2cbf2c8330ab12ea44ab4c0a70