### PR TITLE
Improve watering interaction

### DIFF
--- a/WeedGrowApp/components/PlantCard.tsx
+++ b/WeedGrowApp/components/PlantCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, TouchableOpacity, Image, View } from 'react-native';
-import { IconButton } from 'react-native-paper';
+import { IconButton, Snackbar } from 'react-native-paper';
 import { useRouter } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
@@ -18,6 +18,9 @@ export interface PlantCardProps {
 
 export function PlantCard({ plant, weather }: PlantCardProps) {
   const router = useRouter();
+
+  const [snackVisible, setSnackVisible] = React.useState(false);
+  const [snackMessage, setSnackMessage] = React.useState('');
 
   const ctx: PlantAdviceContext = {
     rainToday: weather?.rainToday ?? false,
@@ -65,20 +68,30 @@ export function PlantCard({ plant, weather }: PlantCardProps) {
         description: 'Watered the plant',
         updatedBy: 'demoUser',
       });
-    } catch (err) {
+      setSnackMessage('Watering logged');
+      setSnackVisible(true);
+    } catch (err: any) {
       console.error('Failed to log watering:', err);
+      setSnackMessage(err.message || 'Failed to log');
+      setSnackVisible(true);
     }
   };
 
 
   return (
-    <TouchableOpacity
-      onPress={() => router.push({ pathname: '/plant/[id]', params: { id: plant.id } })}
-    >
-      <ThemedView style={[styles.card, { borderLeftColor: borderColor }]}>
+    <>
+      <TouchableOpacity
+        onPress={() =>
+          router.push({ pathname: '/plant/[id]', params: { id: plant.id } })
+        }
+      >
+        <ThemedView style={[styles.card, { borderLeftColor: borderColor }]}>
         <IconButton
           icon="water"
-          size={20}
+          size={28}
+          mode="contained"
+          iconColor="white"
+          containerColor="#1e90ff"
           style={styles.waterButton}
           onPress={handleWater}
           accessibilityLabel="Log watering"
@@ -103,8 +116,16 @@ export function PlantCard({ plant, weather }: PlantCardProps) {
             <InfoTooltip message={reason} />
           </View>
         </View>
-      </ThemedView>
-    </TouchableOpacity>
+        </ThemedView>
+      </TouchableOpacity>
+      <Snackbar
+        visible={snackVisible}
+        onDismiss={() => setSnackVisible(false)}
+        duration={3000}
+      >
+        {snackMessage}
+      </Snackbar>
+    </>
   );
 }
 

--- a/WeedGrowApp/lib/logs/addPlantLog.ts
+++ b/WeedGrowApp/lib/logs/addPlantLog.ts
@@ -1,8 +1,38 @@
-import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
+import {
+  collection,
+  addDoc,
+  serverTimestamp,
+  query,
+  where,
+  getDocs,
+  Timestamp,
+} from 'firebase/firestore';
 import { db } from '@/services/firebase';
 import type { PlantLog } from '@/firestoreModels';
 
-export async function addPlantLog(plantId: string, log: Omit<PlantLog, 'timestamp'>): Promise<void> {
+export async function addPlantLog(
+  plantId: string,
+  log: Omit<PlantLog, 'timestamp'>,
+): Promise<void> {
+  if (log.type === 'watering') {
+    const start = new Date();
+    start.setHours(0, 0, 0, 0);
+    const end = new Date();
+    end.setHours(23, 59, 59, 999);
+
+    const q = query(
+      collection(db, 'plants', plantId, 'logs'),
+      where('type', '==', 'watering'),
+      where('timestamp', '>=', Timestamp.fromDate(start)),
+      where('timestamp', '<=', Timestamp.fromDate(end)),
+    );
+
+    const snap = await getDocs(q);
+    if (!snap.empty) {
+      throw new Error('Watering already logged today');
+    }
+  }
+
   await addDoc(collection(db, 'plants', plantId, 'logs'), {
     ...log,
     timestamp: serverTimestamp(),


### PR DESCRIPTION
## Summary
- enlarge watering button and use blue accent color
- show Snackbar feedback
- prevent logging multiple watering actions per day

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm run lint` in `weed-grow-web` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846094b4720833096ef2aaa567afc9e