### PR TITLE
Remove dev error overlay

### DIFF
--- a/WeedGrowApp/components/PlantCard.tsx
+++ b/WeedGrowApp/components/PlantCard.tsx
@@ -70,12 +70,11 @@ export function PlantCard({ plant, weather }: PlantCardProps) {
       });
       setSnackMessage('Watering logged');
       setSnackVisible(true);
-    } catch (err: any) {
-      console.error('Failed to log watering:', err);
-      setSnackMessage(err.message || 'Failed to log');
-      setSnackVisible(true);
-    }
-  };
+      } catch (err: any) {
+        setSnackMessage(err.message || 'Failed to log');
+        setSnackVisible(true);
+      }
+    };
 
 
   return (


### PR DESCRIPTION
## Summary
- remove console.error so logging watering doesn't trigger RN's LogBox overlay

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68460cff59a08330b8cd66f7ed219e88