### PR TITLE
Add watering history display

### DIFF
--- a/WeedGrowApp/app/plant/[id].tsx
+++ b/WeedGrowApp/app/plant/[id].tsx
@@ -17,7 +17,7 @@ import { parseWeatherData } from '@/lib/weather/parseWeatherData';
 import { updateWeatherCache } from '@/lib/weather/updateFirestore';
 import WeatherBar from '@/components/WeatherBar';
 import type { WeatherCacheEntry } from '@/firestoreModels';
-import { fetchWateringHistory, WateringHistoryEntry } from '@/lib/logs/fetchWateringHistory';
+import { fetchWateringHistory, DEFAULT_HISTORY_DAYS, WateringHistoryEntry } from '@/lib/logs/fetchWateringHistory';
 import WateringHistoryBar from '@/components/WateringHistoryBar';
 
 export default function PlantDetailScreen() {
@@ -113,7 +113,7 @@ export default function PlantDetailScreen() {
   useEffect(() => {
     const fetchHistory = async () => {
       if (!id) return;
-      const h = await fetchWateringHistory(String(id), 5);
+      const h = await fetchWateringHistory(String(id), DEFAULT_HISTORY_DAYS);
       setHistory(h);
     };
     fetchHistory();
@@ -184,9 +184,9 @@ export default function PlantDetailScreen() {
         </View>
       )}
 
-      {history.length === 5 && (
+      {history.length === DEFAULT_HISTORY_DAYS && (
         <View style={styles.section}>
-          <ThemedText type="subtitle">Last 5 Days</ThemedText>
+          <ThemedText type="subtitle">Last {DEFAULT_HISTORY_DAYS} Days</ThemedText>
           <WateringHistoryBar history={history} />
         </View>
       )}

--- a/WeedGrowApp/components/WateringHistoryBar.tsx
+++ b/WeedGrowApp/components/WateringHistoryBar.tsx
@@ -24,6 +24,8 @@ export default function WateringHistoryBar({ history }: WateringHistoryBarProps)
               name="water"
               size={24}
               color={h.watered ? Colors[theme].tint : Colors[theme].gray}
+              accessibilityLabel={h.watered ? `${label} watered` : `${label} not watered`}
+              accessible
             />
             <ThemedText style={styles.label}>{label}</ThemedText>
           </View>

--- a/WeedGrowApp/lib/logs/fetchWateringHistory.ts
+++ b/WeedGrowApp/lib/logs/fetchWateringHistory.ts
@@ -1,6 +1,8 @@
 import { collection, getDocs, query, Timestamp, where } from 'firebase/firestore';
 import { db } from '@/services/firebase';
 
+export const DEFAULT_HISTORY_DAYS = 5;
+
 export interface WateringHistoryEntry {
   date: string; // YYYY-MM-DD
   watered: boolean;
@@ -12,11 +14,11 @@ export interface WateringHistoryEntry {
  */
 export async function fetchWateringHistory(
   plantId: string,
-  days = 5,
+  days = DEFAULT_HISTORY_DAYS,
 ): Promise<WateringHistoryEntry[]> {
   const end = new Date();
   end.setHours(23, 59, 59, 999);
-  const start = new Date();
+  const start = new Date(end);
   start.setDate(end.getDate() - (days - 1));
   start.setHours(0, 0, 0, 0);
 
@@ -34,7 +36,7 @@ export async function fetchWateringHistory(
 
   const history: WateringHistoryEntry[] = [];
   for (let i = days - 1; i >= 0; i--) {
-    const d = new Date();
+    const d = new Date(end);
     d.setDate(end.getDate() - i);
     const iso = d.toISOString().split('T')[0];
     history.push({ date: iso, watered: wateredDates.has(iso) });


### PR DESCRIPTION
## Summary
- show recent watering dates on plant details
- fetch watering history from Firestore

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm run lint` in `weed-grow-web` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68460f1bb0888330967c1b3add5d669e