### PR TITLE
Fix duplicate key warning in WeatherBar

### DIFF
--- a/WeedGrowApp/components/WeatherBar.tsx
+++ b/WeedGrowApp/components/WeatherBar.tsx
@@ -21,7 +21,7 @@ export default function WeatherBar({ data }: WeatherBarProps) {
   return (
     <View style={styles.container}>
       {data.map((entry, idx) => (
-        <View key={idx} style={styles.day}>
+        <View key={`${entry?.date ?? 'day'}-${idx}`} style={styles.day}>
           <MaterialCommunityIcons
             name={entry && entry.rainfall > 0 ? 'weather-rainy' : 'weather-sunny'}
             size={24}


### PR DESCRIPTION
## Summary
- avoid React key collisions in `WeatherBar`

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846104ef74083308bce7e0306075253