### PR TITLE
Fix duplicate key warning

### DIFF
--- a/WeedGrowApp/components/WateringHistoryBar.tsx
+++ b/WeedGrowApp/components/WateringHistoryBar.tsx
@@ -15,11 +15,11 @@ export default function WateringHistoryBar({ history }: WateringHistoryBarProps)
 
   return (
     <View style={styles.container}>
-      {history.map((h) => {
+      {history.map((h, idx) => {
         const date = new Date(h.date);
         const label = date.toLocaleDateString(undefined, { weekday: 'short' });
         return (
-          <View key={h.date} style={styles.day}>
+          <View key={`${h.date}-${idx}`} style={styles.day}>
             <MaterialCommunityIcons
               name="water"
               size={24}


### PR DESCRIPTION
## Summary
- avoid duplicate keys in `WateringHistoryBar`

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684612ded3e48330ab64ae6e5dd163e0