### PR TITLE
Implement group list for Home screen

### DIFF
--- a/WeedGrowApp/app/(tabs)/index.tsx
+++ b/WeedGrowApp/app/(tabs)/index.tsx
@@ -1,14 +1,39 @@
-import React, { useState, useEffect } from 'react';
-import { StyleSheet, View } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { StyleSheet, FlatList, TouchableOpacity } from 'react-native';
 import { Image } from 'expo-image';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { ActivityIndicator } from 'react-native-paper';
 
 import ParallaxScrollView from '@/components/ParallaxScrollView';
+import { ThemedText } from '@/components/ThemedText';
+import GroupCard from '@/components/GroupCard';
+import { getUserGroups } from '@/lib/groups';
+import type { Group } from '@/firestoreModels';
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
 
 export default function HomeScreen() {
-  const [ready, setReady] = useState(false);
+  const [groups, setGroups] = useState<(Group & { id: string })[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+  type Theme = keyof typeof Colors;
+  const theme = (useColorScheme() ?? 'dark') as Theme;
 
   useEffect(() => {
-    setReady(true);
+    const fetch = async () => {
+      try {
+        const data = await getUserGroups('demoUser');
+        setGroups(data);
+      } catch (e: any) {
+        console.error('Error fetching groups', e);
+        setError(e.message || 'Failed to load groups');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetch();
   }, []);
 
   return (
@@ -21,7 +46,31 @@ export default function HomeScreen() {
         />
       }
     >
-      {/* Removed calendar and related components */}
+      {loading && (
+        <ActivityIndicator style={styles.loading} color={Colors[theme].tint} />
+      )}
+      {error && <ThemedText>❌ {error}</ThemedText>}
+      {!loading && !error && groups.length === 0 && (
+        <ThemedText>No groups found.</ThemedText>
+      )}
+      {!loading && !error && groups.length > 0 && (
+        <FlatList
+          data={groups}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => <GroupCard group={item} />}
+        />
+      )}
+      <TouchableOpacity
+        accessibilityLabel="Add Group"
+        onPress={() => router.push('/add-group')}
+        style={[styles.fab, { backgroundColor: Colors[theme].tint }]}
+      >
+        <MaterialCommunityIcons
+          name="plus"
+          size={28}
+          color={Colors[theme].white}
+        />
+      </TouchableOpacity>
     </ParallaxScrollView>
   );
 }
@@ -34,17 +83,18 @@ const styles = StyleSheet.create({
     left: 0,
     position: 'absolute',
   },
-  knob: {
-    width: 0,
-    height: 0,
-    backgroundColor: 'transparent',
-    borderLeftWidth: 10,
-    borderRightWidth: 10,
-    borderBottomWidth: 10,
-    borderLeftColor: 'transparent',
-    borderRightColor: 'transparent',
-    borderBottomColor: 'green',
-    alignSelf: 'center',
-    marginVertical: 10,
+  loading: {
+    marginTop: 20,
+  },
+  fab: {
+    position: 'absolute',
+    right: 20,
+    bottom: 20,
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+    elevation: 5,
   },
 });

--- a/WeedGrowApp/components/GroupCard.tsx
+++ b/WeedGrowApp/components/GroupCard.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+import { calendarGreen } from '@/constants/Colors';
+import type { Group } from '@/firestoreModels';
+
+export interface GroupCardProps {
+  group: Group & { id: string };
+}
+
+export default function GroupCard({ group }: GroupCardProps) {
+  const router = useRouter();
+  const envIcon =
+    group.environment === 'indoor'
+      ? 'home'
+      : group.environment === 'outdoor'
+      ? 'weather-sunny'
+      : 'greenhouse';
+  return (
+    <TouchableOpacity
+      onPress={() =>
+        router.push({ pathname: '/group/[id]', params: { id: group.id } })
+      }
+    >
+      <ThemedView style={styles.card}>
+        <View style={styles.row}>
+          <MaterialCommunityIcons
+            name={envIcon}
+            size={24}
+            color="white"
+            style={styles.icon}
+          />
+          <ThemedText type="subtitle" style={styles.name}>
+            {group.name}
+          </ThemedText>
+        </View>
+        <ThemedText>
+          {group.plantIds.length} {group.plantIds.length === 1 ? 'plant' : 'plants'}
+        </ThemedText>
+      </ThemedView>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: 16,
+    padding: 12,
+    borderRadius: 12,
+    backgroundColor: calendarGreen,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  icon: {
+    marginRight: 8,
+  },
+  name: {
+    flex: 1,
+  },
+});


### PR DESCRIPTION
## Summary
- show user groups on the Home tab
- create `GroupCard` component for displaying group info

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846cac4d9a88330b2a16b04f5976120