### PR TITLE
Implement water all action

### DIFF
--- a/WeedGrowApp/components/GroupCard.tsx
+++ b/WeedGrowApp/components/GroupCard.tsx
@@ -24,6 +24,7 @@ export interface GroupCardProps {
   /** Optional label like "2 days ago" */
   lastWatered?: string;
   onWaterAll?: () => void;
+  waterDisabled?: boolean;
   onEdit?: () => void;
 }
 
@@ -33,6 +34,7 @@ export default function GroupCard({
   weatherData,
   lastWatered,
   onWaterAll,
+  waterDisabled = false,
   onEdit,
 }: GroupCardProps) {
   const router = useRouter();
@@ -65,6 +67,7 @@ export default function GroupCard({
             size={24}
             mode="contained"
             onPress={handleWaterAll}
+            disabled={waterDisabled}
             style={styles.waterButton}
             accessibilityLabel="Water all plants"
           />

--- a/WeedGrowApp/lib/groups/index.ts
+++ b/WeedGrowApp/lib/groups/index.ts
@@ -72,3 +72,23 @@ export async function addWaterLogsToGroupPlants(groupId: string): Promise<void> 
     )
   );
 }
+
+/** Water all plants in the group using the provided userId. */
+export async function waterAllPlantsInGroup(
+  groupId: string,
+  userId: string,
+): Promise<void> {
+  const snap = await getDoc(doc(db, 'groups', groupId));
+  if (!snap.exists()) return;
+  const group = snap.data() as Group;
+  await Promise.all(
+    group.plantIds.map((pid) =>
+      addDoc(collection(db, 'plants', pid, 'logs'), {
+        type: 'watering',
+        timestamp: serverTimestamp(),
+        description: 'Group watering',
+        updatedBy: userId,
+      }),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
- add `waterAllPlantsInGroup` helper for bulk watering
- enable disabling water button in `GroupCard`
- wire up water all action on home screen with snackbar feedback

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d3c206908330bca1d967ce52c162